### PR TITLE
Bump Common Custom User Data Gradle plugin from 1.12.1 to 1.12.2

### DIFF
--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -11,7 +11,7 @@ spec:
       default: 'false'
     # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
     ccudPluginVersion:
-      default: '1.12.1'
+      default: '1.12.2'
     # Allow untrusted server
     allowUntrustedServer:
       default: 'false'


### PR DESCRIPTION
This PR bumps Common Custom User Data Gradle plugin from `1.12.1` to `1.12.2`.