### PR TITLE
Add custom extensions detection and enforce url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .DS_Store
+build/

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ include:
 
 build-gradle-job:
   stage: build
-  before_script:
-    - !reference [.injectDevelocityForGradle]
   script:
+    - !reference [.injectDevelocityForGradle]
     - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH # Will publish a build scan to https://develocity.mycompany.com
 ```
 The `.injectDevelocityForGradle` creates an init script with the instrumentation logic and exports the path as `$DEVELOCITY_INIT_SCRIPT_PATH` environment variable.
@@ -49,9 +48,8 @@ include:
 
 build-maven-job:
   stage: build
-  before_script:
-    - !reference [.injectDevelocityForMaven]
   script:
+    - !reference [.injectDevelocityForMaven]
     - ./mvnw clean verify # Will publish a build scan to https://develocity.mycompany.com
 ```
 
@@ -76,16 +74,14 @@ include:
 
 build-maven-job:
   stage: build
-  before_script:
-    - !reference [.injectDevelocityForMaven]
   script:
+    - !reference [.injectDevelocityForMaven]
     - ./mvnw clean verify # Will publish a build scan to https://develocity.mycompany.com
 
 build-gradle-job:
   stage: build
-  before_script:
-    - !reference [.injectDevelocityForGradle]
   script:
+    - !reference [.injectDevelocityForGradle]
     - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH # Will publish a build scan to https://develocity.mycompany.com
 ```
 

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -17,7 +17,7 @@ spec:
       default: 'false'
 
 ---
-.injectDevelocityForGradle: &injectDevelocityForGradle |
+.injectDevelocityForGradle: |
   function create_gradle_init() {
     local tmp_ge=$(mktemp -d ge.XXXXXX --tmpdir="${CI_PROJECT_DIR}")
     local init_script="${tmp_ge}/init-script.gradle"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -126,11 +126,15 @@ spec:
       if [ "${elementName}" = "artifactId"  ]
       then
         currentExtension="${currentExtension}:${value}"
-        if [[ "${extCoordinates}" == *"${currentExtension}"* ]]
-        then
-          echo "true"
-          return
-        fi
+      fi
+      if [ "${elementName}" = "version"  ]
+      then
+        currentExtension="${currentExtension}:${value}"
+      fi
+      if [[ "${currentExtension}" =~ ^.*:.*:.*$ && "${currentExtension}" == *"${extCoordinates}"* ]]
+      then
+        echo "true"
+        return
       fi
     done < "${extFile}"
     echo "false"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -15,29 +15,134 @@ spec:
     # Allow untrusted server
     allowUntrustedServer:
       default: 'false'
+    # Enforce URL
+    enforceUrl:
+      default: 'true'
+    # Will not inject the Develocity extension if an extension with provided coordinates is found.
+    # Expected format 'groupId:artifactId(:version)'
+    mavenExtensionCustomCoordinates:
+      default: ''
+    # Will not inject the CCUD extension if an extension with provided coordinates is found.
+    # Expected format 'groupId:artifactId(:version)'
+    ccudExtensionCustomCoordinates:
+      default: ''
 ---
-.injectDevelocityForMaven: &injectDevelocityForMaven |
-  function create_tmp() {
+.injectDevelocityForMaven: |
+  ccudMavenExtensionVersion=$[[ inputs.ccudMavenExtensionVersion ]]
+  mavenRepo=$[[ inputs.mavenRepo ]]
+  mavenExtensionVersion=$[[ inputs.mavenExtensionVersion ]]
+  allowUntrustedServer=$[[ inputs.allowUntrustedServer ]]
+  enforceUrl=$[[ inputs.enforceUrl ]]
+  customMavenExtensionCoordinates=$[[ inputs.mavenExtensionCustomCoordinates ]]
+  customCcudCoordinates=$[[ inputs.ccudExtensionCustomCoordinates ]]
+  url=$[[ inputs.url ]]
+
+  #functions-start
+  function createTmp() {
     export TMP_GE=$(mktemp -d ge.XXXXXX --tmpdir="${CI_PROJECT_DIR}")
   }
 
-  function download_ge_ccud_ext() {
+  function downloadDvCcudExt() {
     local ext_path="${TMP_GE}/common-custom-user-data-maven-extension.jar"
-    curl -s $[[ inputs.mavenRepo ]]/com/gradle/common-custom-user-data-maven-extension/$[[ inputs.ccudMavenExtensionVersion ]]/common-custom-user-data-maven-extension-$[[ inputs.ccudMavenExtensionVersion ]].jar -o "${ext_path}"
+    curl -s "${mavenRepo}/com/gradle/common-custom-user-data-maven-extension/${ccudMavenExtensionVersion}/common-custom-user-data-maven-extension-${ccudMavenExtensionVersion}.jar" -o "${ext_path}"
     export CCUD_EXT_PATH="${ext_path}"
   }
 
-  function download_ge_maven_ext() {
+  function downloadDvMavenExt() {
     local ext_path="${TMP_GE}/gradle-enterprise-maven-extension.jar"
-    curl -s $[[ inputs.mavenRepo ]]/com/gradle/gradle-enterprise-maven-extension/$[[ inputs.mavenExtensionVersion ]]/gradle-enterprise-maven-extension-$[[ inputs.mavenExtensionVersion ]].jar -o "${ext_path}"
+    curl -s "${mavenRepo}/com/gradle/gradle-enterprise-maven-extension/${mavenExtensionVersion}/gradle-enterprise-maven-extension-${mavenExtensionVersion}.jar" -o "${ext_path}"
     export DEVELOCITY_EXT_PATH="${ext_path}"
   }
 
-  function inject_develocity_for_maven() {
-    export "MAVEN_OPTS=-Dmaven.ext.class.path=${DEVELOCITY_EXT_PATH}:${CCUD_EXT_PATH} -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=$[[ inputs.url ]] -Dgradle.enterprise.allowUntrustedServer=$[[ inputs.allowUntrustedServer ]]"
+  function injectDevelocityForMaven() {
+    local rootDir=$1
+    local mavenOpts="-Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=${allowUntrustedServer}"
+    local mavenExtClasspath=''
+    local appliedCustomDv=0
+    local appliedCustomCcud=0
+    local appliedCustomDv=$(detectExtension "${rootDir}" "$(dvCoordinates)")
+    if [ "${appliedCustomDv}" = "false" ]
+    then
+      mavenExtClasspath="${DEVELOCITY_EXT_PATH}"
+    fi
+    local appliedCustomCcud=$(detectExtension "${rootDir}" "$(ccudCoordinates)")
+    if [ "${appliedCustomCcud}" = "false" ]
+    then
+      if [ ! -z "${mavenExtClasspath}" ]
+      then
+        mavenExtClasspath+=":"
+      fi
+      mavenExtClasspath="${mavenExtClasspath}${CCUD_EXT_PATH}"
+    fi
+    if [ ! -z "${mavenExtClasspath}" ]
+    then
+      mavenOpts="-Dmaven.ext.class.path=${mavenExtClasspath} ${mavenOpts}"
+    fi
+    if [[ ("${appliedCustomDv}" = "true" || "${appliedCustomCcud}" = "true") && "${enforceUrl}" = 'true' ]]
+    then
+      mavenOpts="${mavenOpts} -Dgradle.enterprise.url=${url}"
+    elif [[ "${appliedCustomDv}" = "false" && "${appliedCustomCcud}" = "false" ]]
+    then
+      mavenOpts="${mavenOpts} -Dgradle.enterprise.url=${url}"
+    fi
+    local existingMavenOpts=$(if [ ! -z "$MAVEN_OPTS" ]; then echo "${MAVEN_OPTS} "; else echo ''; fi)
+    export MAVEN_OPTS=${existingMavenOpts}${mavenOpts}
   }
 
-  create_tmp
-  download_ge_ccud_ext
-  download_ge_maven_ext
-  inject_develocity_for_maven
+  function dvCoordinates() {
+    local coordinates='com.gradle:gradle-enterprise-maven-extension'
+    if [ ! -z "${customMavenExtensionCoordinates}" ]
+    then
+      coordinates="${customMavenExtensionCoordinates}"
+    fi
+    echo "${coordinates}"
+  }
+
+  function ccudCoordinates() {
+    local coordinates='com.gradle:gradle-enterprise-maven-extension'
+    if [ ! -z "${customCcudCoordinates}" ]
+    then
+      coordinates="${customCcudCoordinates}"
+    fi
+    echo "${coordinates}"
+  }
+
+  function detectExtension() {
+    local rootDir=$1
+    local extCoordinates=$2
+    local extFile="${rootDir}/.mvn/extensions.xml"
+    if [ ! -f "${extFile}" ]
+    then
+      echo "false"
+      return
+    fi
+    local currentExtension
+    while readXml
+    do
+      if [ "${elementName}" = "groupId"  ]
+      then
+        currentExtension="${value}"
+      fi
+      if [ "${elementName}" = "artifactId"  ]
+      then
+        currentExtension="${currentExtension}:${value}"
+        if [[ "${extCoordinates}" == *"${currentExtension}"* ]]
+        then
+          echo "true"
+          return
+        fi
+      fi
+    done < "${extFile}"
+    echo "false"
+  }
+
+  function readXml() {
+    local IFS=\>
+    read -d \< elementName value
+  }
+  #functions-end
+
+  createTmp
+  downloadDvCcudExt
+  downloadDvMavenExt
+  injectDevelocityForMaven "${PWD}"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -58,8 +58,8 @@ spec:
     local rootDir=$1
     local mavenOpts="-Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=${allowUntrustedServer}"
     local mavenExtClasspath=''
-    local appliedCustomDv=0
-    local appliedCustomCcud=0
+    local appliedCustomDv="false"
+    local appliedCustomCcud="false"
     local appliedCustomDv=$(detectExtension "${rootDir}" "$(dvCoordinates)")
     if [ "${appliedCustomDv}" = "false" ]
     then

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -18,7 +18,7 @@ spec:
     # Enforce URL
     enforceUrl:
       default: 'true'
-    # Will not inject the Develocity extension if an extension with provided coordinates is found.
+    # Will not inject the Develocity Maven extension if an extension with provided coordinates is found.
     # Expected format 'groupId:artifactId(:version)'
     mavenExtensionCustomCoordinates:
       default: ''

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+#set -xv
+buildDir="$(dirname $0)/build"
+DEVELOCITY_EXT_PATH="/path/to/gradle-enterprise-maven-extension.jar"
+CCUD_EXT_PATH="/path/to/common-custom-user-data-maven-extension.jar"
+
+function test_detectExtension_detected() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <extensions>
+        <extension>
+            <groupId>com.gradle</groupId>
+            <artifactId>gradle-enterprise-maven-extension</artifactId>
+            <version>1.20.1</version>
+        </extension>
+    </extensions>
+EOF
+
+    local result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension")
+
+    echo "test_detectExtension_detected: ${result}"
+    assert "${result}" "true"
+
+    result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension:1.18.3")
+
+    echo "test_detectExtension_detected with version: ${result}"
+    assert "${result}" "true"
+}
+
+function test_detectExtension_notDetected() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <extensions>
+        <extension>
+            <groupId>org.apache.maven.extensions</groupId>
+            <artifactId>maven-enforcer-extension</artifactId>
+            <version>3.4.1</version>
+        </extension>
+    </extensions>
+EOF
+
+    local result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension")
+
+    echo "test_detectExtension_notDetected: ${result}"
+    assert $result "false"
+}
+
+function test_detectExtension_notDetected_junk() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <foo>
+    </foo>
+EOF
+
+    local result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension")
+
+    echo "test_detectExtension_notDetected_junk: ${result}"
+    assert $result "false"
+}
+
+function test_detectExtension_unexisting() {
+    local projDir=$(setupProject)
+
+    local result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension")
+
+    echo "test_detectExtension_notDetected_unexisting: ${result}"
+    assert $result "false"
+}
+
+function test_inject_develocity_for_maven() {
+    local projDir=$(setupProject)
+    allowUntrustedServer=false
+    url=https://localhost
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/gradle-enterprise-maven-extension.jar:/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost"
+}
+
+function test_inject_develocity_for_maven_existing_maven_opts() {
+    local projDir=$(setupProject)
+    allowUntrustedServer=false
+    url=https://localhost
+    MAVEN_OPTS="-Dfoo=bar"
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_maven_opts: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dfoo=bar -Dmaven.ext.class.path=/path/to/gradle-enterprise-maven-extension.jar:/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost"
+}
+
+function test_inject_develocity_for_maven_existing_extension() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>org.apache.maven.extensions</groupId>
+              <artifactId>maven-enforcer-extension</artifactId>
+              <version>3.4.1</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates="org.apache.maven.extensions:maven-enforcer-extension"
+    url=https://localhost
+    enforceUrl=false
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_extension: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false"
+}
+
+function test_inject_develocity_for_maven_existing_extension_enforceUrl() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>org.apache.maven.extensions</groupId>
+              <artifactId>maven-enforcer-extension</artifactId>
+              <version>3.4.1</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates="org.apache.maven.extensions:maven-enforcer-extension"
+    url=https://localhost
+    MAVEN_OPTS=""
+    enforceUrl=true
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_extension_enforceUrl: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost"
+}
+
+function test_inject_develocity_for_maven_existing_ccud_extension() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>org.apache.maven.extensions</groupId>
+              <artifactId>maven-enforcer-extension</artifactId>
+              <version>3.4.1</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates=""
+    customCcudCoordinates="org.apache.maven.extensions:maven-enforcer-extension"
+    url=https://localhost
+    enforceUrl=false
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_ccud_extension: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/gradle-enterprise-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false"
+}
+
+function test_inject_develocity_for_maven_existing_ccud_extension_enforceUrl() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>org.apache.maven.extensions</groupId>
+              <artifactId>maven-enforcer-extension</artifactId>
+              <version>3.4.1</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates=""
+    customCcudCoordinates="org.apache.maven.extensions:maven-enforcer-extension"
+    url=https://localhost
+    enforceUrl=true
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_ccud_extension_enforceUrl: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/gradle-enterprise-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost"
+}
+
+function test_inject_develocity_for_maven_existing_dv_and_ccud_extension_enforceUrl() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>org.apache.maven.extensions</groupId>
+              <artifactId>maven-enforcer-extension</artifactId>
+              <version>3.4.1</version>
+          </extension>
+          <extension>
+              <groupId>org.foo</groupId>
+              <artifactId>bar-extension</artifactId>
+              <version>1.0</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates="org.foo:bar-extension"
+    customCcudCoordinates="org.apache.maven.extensions:maven-enforcer-extension"
+    url=https://localhost
+    enforceUrl=true
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_dv_and_ccud_extension_enforceUrl: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost"
+}
+
+function setupProject() {
+    local projDir="$(mktemp -p ${buildDir} -d ge.XXXXXX)"
+    local extDir="${projDir}/.mvn"
+    mkdir -p "${extDir}"
+
+    echo "${projDir}"
+}
+
+function assert() {
+    local val=$1
+    local expected=$2
+    if [ ! "${val}" = "${expected}" ]
+    then
+        echo "${val} not equal to expected ${expected}"
+        exit 1
+    fi
+}
+
+function extractCodeUnderTest() {
+    local start_pattern="#functions-start"
+    local end_pattern="#functions-end"
+    local file="$(dirname $0)/develocity-maven.yml"
+
+    sed -n "/$start_pattern/,/$end_pattern/p" "$file" | sed '/^$/d' > "${buildDir}/under-test.sh"
+    source "${buildDir}/under-test.sh"
+}
+
+function clean() {
+    echo "removing ${buildDir}"
+    rm -Rf "${buildDir}"
+    mkdir "${buildDir}"
+}
+
+clean
+extractCodeUnderTest
+test_detectExtension_detected
+test_detectExtension_notDetected
+test_detectExtension_notDetected_junk
+test_detectExtension_unexisting
+test_inject_develocity_for_maven
+test_inject_develocity_for_maven_existing_maven_opts
+test_inject_develocity_for_maven_existing_extension
+test_inject_develocity_for_maven_existing_extension_enforceUrl
+test_inject_develocity_for_maven_existing_ccud_extension
+test_inject_develocity_for_maven_existing_ccud_extension_enforceUrl
+test_inject_develocity_for_maven_existing_dv_and_ccud_extension_enforceUrl

--- a/test.sh
+++ b/test.sh
@@ -22,9 +22,43 @@ EOF
     echo "test_detectExtension_detected: ${result}"
     assert "${result}" "true"
 
-    result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension:1.18.3")
+    result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension:1.20.1")
 
     echo "test_detectExtension_detected with version: ${result}"
+    assert "${result}" "true"
+
+    result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension:1.18.1")
+
+    echo "test_detectExtension_detected with wrong version: ${result}"
+    assert "${result}" "false"
+}
+
+function test_detectExtension_multiple_detected() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <extensions>
+        <extension>
+            <groupId>foo</groupId>
+            <artifactId>bar</artifactId>
+            <version>1.20.1</version>
+        </extension>
+        <extension>
+            <groupId>foo</groupId>
+            <artifactId>bar2</artifactId>
+            <version>1.20.1</version>
+        </extension>
+        <extension>
+            <groupId>com.gradle</groupId>
+            <artifactId>gradle-enterprise-maven-extension</artifactId>
+            <version>1.20.1</version>
+        </extension>
+    </extensions>
+EOF
+
+    local result=$(detectExtension "${projDir}" "com.gradle:gradle-enterprise-maven-extension")
+
+    echo "test_detectExtension_multiple_detected: ${result}"
     assert "${result}" "true"
 }
 
@@ -261,6 +295,7 @@ test_detectExtension_detected
 test_detectExtension_notDetected
 test_detectExtension_notDetected_junk
 test_detectExtension_unexisting
+test_detectExtension_multiple_detected
 test_inject_develocity_for_maven
 test_inject_develocity_for_maven_existing_maven_opts
 test_inject_develocity_for_maven_existing_extension


### PR DESCRIPTION
This adds 2 new input parameters to the Maven extension:
- `mavenExtensionCustomCoordinates`
When set, the referenced script `injectDevelocityForMaven` will check if this extension is in `.mvn/extensions.xml`. If so, it won't inject the Develocity Maven extension.
- `ccudExtensionCustomCoordinates`
When set, the referenced script `injectDevelocityForMaven` will check if this extension is in `.mvn/extensions.xml`. If so, it won't inject the CCUD Maven extension.

Note that because of this lookup in the current dir, we now advise referencing the script just before the build is executed, instead of `before_script`, so if there's been a folder change, the extensions detection will still work.

This PR also takes into account an existing `MAVEN_OPTS` and appends to it.
