### PR TITLE
Add capture task/goal inputs option

### DIFF
--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -18,7 +18,7 @@ spec:
     # Enforce the url over any defined locally to the project
     enforceUrl:
       default: 'false'
-    # Capture task input files, if set it'll override what is already effective in the current project
+    # Capture task input files, only set if no Develocity plugin is already present
     captureTaskInputFiles:
       default: 'true'
     # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -18,6 +18,9 @@ spec:
     # Enforce the url over any defined locally to the project
     enforceUrl:
       default: 'false'
+    # Capture task input files, if set it'll override what is already effective in the current project
+    captureTaskInputFiles:
+      default: 'true'
     # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
     ccudPluginVersion:
       default: '1.13'
@@ -205,6 +208,7 @@ spec:
 
       def geUrl = getInputParam('develocity.url')
       def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+      def geCaptureTaskInputFiles = Boolean.parseBoolean(getInputParam('develocity.capture-task-input-files'))
       def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
       def gePluginVersion = getInputParam('develocity.plugin.version')
       def ccudPluginVersion = getInputParam('develocity.ccud.plugin.version')
@@ -236,6 +240,14 @@ spec:
                           buildScan.publishAlways()
                           if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = false  // uploadInBackground not available for build-scan-plugin 1.16
                           buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                          if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                              logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                              if (isAtLeast(gePluginVersion, '3.7')) {
+                                  buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                              } else {
+                                  buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                              }
+                          }
                       }
 
                       if (geUrl && geEnforceUrl) {
@@ -273,6 +285,14 @@ spec:
                           ext.buildScan.publishAlways()
                           ext.buildScan.uploadInBackground = false
                           ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                          if (isAtLeast(gePluginVersion, '2.1')) {
+                              logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                              if (isAtLeast(gePluginVersion, '3.7')) {
+                                  ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                              } else {
+                                  ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                              }
+                          }
                       }
                   }
 
@@ -314,7 +334,11 @@ spec:
       }
 
       static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
-          GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+          !isAtLeast(versionUnderTest, referenceVersion)
+      }
+
+      static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
+          GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
       }
 
       apply from: "${System.getenv('CI_PROJECT_DIR')}/build-result-capture.init.groovy"
@@ -330,6 +354,7 @@ spec:
     export "DEVELOCITY_CCUD_PLUGIN_VERSION=$[[ inputs.ccudPluginVersion ]]"
     export "DEVELOCITY_ALLOW_UNTRUSTED_SERVER=$[[ inputs.allowUntrustedServer ]]"
     export "DEVELOCITY_ENFORCE_URL=$[[ inputs.enforceUrl ]]"
+    export "DEVELOCITY_CAPTURE_TASK_INPUT_FILES=$[[ inputs.captureTaskInputFiles ]]"
     export "GRADLE_PLUGIN_REPOSITORY_URL=$[[ inputs.gradlePluginRepositoryUrl ]]"
     export "GRADLE_PLUGIN_REPOSITORY_USERNAME=$[[ inputs.gradlePluginRepositoryUsername ]]"
     export "GRADLE_PLUGIN_REPOSITORY_PASSWORD=$[[ inputs.gradlePluginRepositoryPassword ]]"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -18,7 +18,7 @@ spec:
     # Enforce URL
     enforceUrl:
       default: 'true'
-    # Capture goal input files, if set it'll override what is already effective in the current project
+    # Capture goal input files, only set if no Develocity extension is already present
     captureGoalInputFiles:
       default: 'true'
     # Will not inject the Develocity Maven extension if an extension with provided coordinates is found.

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -18,6 +18,9 @@ spec:
     # Enforce URL
     enforceUrl:
       default: 'true'
+    # Capture goal input files, if set it'll override what is already effective in the current project
+    captureGoalInputFiles:
+      default: 'true'
     # Will not inject the Develocity Maven extension if an extension with provided coordinates is found.
     # Expected format 'groupId:artifactId(:version)'
     mavenExtensionCustomCoordinates:
@@ -33,6 +36,7 @@ spec:
   mavenExtensionVersion=$[[ inputs.mavenExtensionVersion ]]
   allowUntrustedServer=$[[ inputs.allowUntrustedServer ]]
   enforceUrl=$[[ inputs.enforceUrl ]]
+  captureGoalInputFiles=$[[ inputs.captureGoalInputFiles ]]
   customMavenExtensionCoordinates=$[[ inputs.mavenExtensionCustomCoordinates ]]
   customCcudCoordinates=$[[ inputs.ccudExtensionCustomCoordinates ]]
   url=$[[ inputs.url ]]
@@ -41,11 +45,11 @@ spec:
   function createTmp() {
     export TMP_DV=$(mktemp -d develocity.XXXXXX --tmpdir="${CI_PROJECT_DIR}")
   }
-  
+
   function isAtLeast() {
     local v1=$(printf "%03d%03d%03d%03d" $(echo "$1" | cut -f1 -d"-" | tr '.' ' '))
     local v2=$(printf "%03d%03d%03d%03d" $(echo "$2" | cut -f1 -d"-" | tr '.' ' '))
-    if [ "$v1" -eq "$v2" ] || [ "$v1" -gt "$v2" ] 
+    if [ "$v1" -eq "$v2" ] || [ "$v1" -gt "$v2" ]
     then
       echo "true"
     else
@@ -61,10 +65,10 @@ spec:
 
   function downloadDvMavenExt() {
     local ext_path
-    if [ "$(isAtLeast $mavenExtensionVersion 1.21)" = "true" ] 
+    if [ "$(isAtLeast $mavenExtensionVersion 1.21)" = "true" ]
     then
       ext_path="${TMP_DV}/develocity-maven-extension.jar"
-      curl -s "${mavenRepo}/com/gradle/develocity-maven-extension/${mavenExtensionVersion}/develocity-maven-extension-${mavenExtensionVersion}.jar" -o "${ext_path}"     
+      curl -s "${mavenRepo}/com/gradle/develocity-maven-extension/${mavenExtensionVersion}/develocity-maven-extension-${mavenExtensionVersion}.jar" -o "${ext_path}"
     else
       ext_path="${TMP_DV}/gradle-enterprise-maven-extension.jar"
       curl -s "${mavenRepo}/com/gradle/gradle-enterprise-maven-extension/${mavenExtensionVersion}/gradle-enterprise-maven-extension-${mavenExtensionVersion}.jar" -o "${ext_path}"
@@ -103,10 +107,14 @@ spec:
     then
       mavenOpts="${mavenOpts} -Dgradle.enterprise.url=${url} -Ddevelocity.url=${url}"
     fi
+    if [[ "${appliedCustomDv}" = "false" && ("${captureGoalInputFiles}" = "true" || "${captureGoalInputFiles}" = "false") ]]
+    then
+      mavenOpts="${mavenOpts} -Dgradle.scan.captureGoalInputFiles=${captureGoalInputFiles}"
+    fi
     local existingMavenOpts=$(if [ ! -z "$MAVEN_OPTS" ]; then echo "${MAVEN_OPTS} "; else echo ''; fi)
     export MAVEN_OPTS=${existingMavenOpts}${mavenOpts}
   }
-  
+
   function detectDvExtension() {
     local rootDir=$1
     if [ ! -z "${customMavenExtensionCoordinates}" ]
@@ -123,7 +131,7 @@ spec:
   }
 
   function ccudCoordinates() {
-    local coordinates='com.gradle:gradle-enterprise-maven-extension'
+    local coordinates='com.gradle:common-custom-user-data-maven-extension'
     if [ ! -z "${customCcudCoordinates}" ]
     then
       coordinates="${customCcudCoordinates}"

--- a/test_maven.sh
+++ b/test_maven.sh
@@ -346,6 +346,31 @@ EOF
     assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/develocity-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false"
 }
 
+function test_inject_develocity_for_maven_existing_default_ccud_extension() {
+    local projDir=$(setupProject)
+    cat << EOF >"${projDir}/.mvn/extensions.xml"
+      <?xml version="1.0" encoding="UTF-8"?>
+      <extensions>
+          <extension>
+              <groupId>com.gradle</groupId>
+              <artifactId>common-custom-user-data-maven-extension</artifactId>
+              <version>1.13</version>
+          </extension>
+      </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates=""
+    customCcudCoordinates=""
+    url=https://localhost
+    enforceUrl=false
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_develocity_for_maven_existing_default_ccud_extension: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/develocity-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false"
+}
+
 function test_inject_develocity_for_maven_existing_ccud_extension_enforceUrl() {
     local projDir=$(setupProject)
     cat << EOF >"${projDir}/.mvn/extensions.xml"
@@ -399,6 +424,58 @@ EOF
 
     echo "test_inject_develocity_for_maven_existing_dv_and_ccud_extension_enforceUrl: ${MAVEN_OPTS}"
     assert "${MAVEN_OPTS}" "-Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost -Ddevelocity.url=https://localhost"
+}
+
+function test_inject_capture_goal_input_files_true() {
+    local projDir=$(setupProject)
+    allowUntrustedServer=false
+    url=https://localhost
+    captureGoalInputFiles=true
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_capture_goal_input_files_true: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/develocity-maven-extension.jar:/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost -Ddevelocity.url=https://localhost -Dgradle.scan.captureGoalInputFiles=true"
+}
+
+function test_inject_capture_goal_input_files_false() {
+    local projDir=$(setupProject)
+    allowUntrustedServer=false
+    url=https://localhost
+    captureGoalInputFiles=false
+    MAVEN_OPTS=""
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_capture_goal_input_files_false: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/develocity-maven-extension.jar:/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false -Dgradle.enterprise.url=https://localhost -Ddevelocity.url=https://localhost -Dgradle.scan.captureGoalInputFiles=false"
+}
+
+function test_inject_capture_goal_input_files_existing_ext() {
+    local projDir=$(setupProject)
+        cat << EOF >"${projDir}/.mvn/extensions.xml"
+          <?xml version="1.0" encoding="UTF-8"?>
+          <extensions>
+              <extension>
+                  <groupId>com.gradle</groupId>
+                  <artifactId>develocity-maven-extension</artifactId>
+                  <version>1.21</version>
+              </extension>
+          </extensions>
+EOF
+    allowUntrustedServer=false
+    customMavenExtensionCoordinates=""
+    customCcudCoordinates=""
+    url=https://localhost
+    MAVEN_OPTS=""
+    enforceUrl=false
+    captureGoalInputFiles=false
+
+    injectDevelocityForMaven "${projDir}"
+
+    echo "test_inject_capture_goal_input_files_existing_ext: ${MAVEN_OPTS}"
+    assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false"
 }
 
 function setupProject() {
@@ -458,5 +535,9 @@ test_inject_develocity_for_maven_existing_maven_opts
 test_inject_develocity_for_maven_existing_extension
 test_inject_develocity_for_maven_existing_extension_enforceUrl
 test_inject_develocity_for_maven_existing_ccud_extension
+test_inject_develocity_for_maven_existing_default_ccud_extension
 test_inject_develocity_for_maven_existing_ccud_extension_enforceUrl
 test_inject_develocity_for_maven_existing_dv_and_ccud_extension_enforceUrl
+test_inject_capture_goal_input_files_true
+test_inject_capture_goal_input_files_false
+test_inject_capture_goal_input_files_existing_ext


### PR DESCRIPTION
This PR adds capture task input files and capture goal input files options:

- default value is "true"
- whether it's true or false, it'll be set only if the current project does not have a Develocity plugin/extension already configured