### PR TITLE
Use short-lived access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The templates can also be configured to ad-hoc connect Gradle and Maven builds t
 
 
 ## Requirements
+- Develocity 2024.1 or above
 - GitLab 15.11 since they use [inputs](https://docs.gitlab.com/ee/ci/yaml/inputs.html).
 - Shell with curl should be available on the executor
 - Network access to download from Maven central and from GitHub (those URLs can be customized, see [Configuration](#Configuration)
@@ -147,6 +148,7 @@ For the Common Custom User Data Maven extension which is defined with the `ccudM
 To authenticate against the Develocity server, you should specify a masked environment variable named `DEVELOCITY_ACCESS_KEY`.
 See [here](https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-ui) on how to do this in GitLab UI.
 To generate a Develocity Access Key, you can check [Develocity Gradle plugin docs](https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration) and [Develocity Maven extension docs](https://docs.gradle.com/enterprise/maven-extension/#manual_access_key_configuration).
+A short-lived access token will be retrieved given the access key and will replace the `DEVELOCITY_ACCESS_KEY` variable.
 
 ## License
 This project is available under the [Apache License, Version 2.0](https://github.com/gradle/develocity-gitlab-templates/blob/main/LICENSE).

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -132,7 +132,7 @@ spec:
   EOF
   }
 
-  function create_gradle_init() {
+  function createGradleInit() {
     local init_script="${CI_PROJECT_DIR}/init-script.gradle"
 
     cat > $init_script <<'EOF'

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -4,8 +4,17 @@ spec:
     url:
       default: 'https://scans.gradle.com'
     # Develocity Plugin version
+    # Allow untrusted server
+    allowUntrustedServer:
+      default: 'false'
+    # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
+    shortLivedTokensExpiry:
+      default: ''
     gradlePluginVersion:
       default: '3.17.1'
+    # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
+    ccudPluginVersion:
+      default: '2.0'
     # Develocity Gradle plugin repository URL, defaults in the init script to https://plugins.gradle.org/m2
     gradlePluginRepositoryUrl:
       default: ''
@@ -15,21 +24,12 @@ spec:
     # Develocity Gradle plugin repository password, strongly advised to pass a protected and masked variable
     gradlePluginRepositoryPassword:
       default: ''
-    # Enforce the url over any defined locally to the project
-    enforceUrl:
-      default: 'false'
     # Capture file fingerprints, only set if no Develocity plugin is already present
     captureFileFingerprints:
       default: 'true'
-    # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
-    ccudPluginVersion:
-      default: '2.0'
-    # Allow untrusted server
-    allowUntrustedServer:
+    # Enforce the url over any defined locally to the project
+    enforceUrl:
       default: 'false'
-    # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
-    shortLivedTokensExpiry:
-      default: ''
 
 ---
 .build_scan_links_report:

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -27,6 +27,9 @@ spec:
     # Allow untrusted server
     allowUntrustedServer:
       default: 'false'
+    # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
+    shortLivedTokensExpiry:
+      default: ''
 
 ---
 .build_scan_links_report:
@@ -35,11 +38,11 @@ spec:
       annotations: $CI_PROJECT_DIR/build-scan-links.json
 
 .injectDevelocityForGradle: |
-  function create_gradle_report_init() {
-    local init_script="${CI_PROJECT_DIR}/build-result-capture.init.groovy"
+  function createGradleReportInit() {
+    local initScript="${CI_PROJECT_DIR}/build-result-capture.init.groovy"
     export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
 
-    cat > $init_script <<'EOF'
+    cat > $initScript <<'EOF'
       import org.gradle.util.GradleVersion
       import java.util.concurrent.atomic.AtomicBoolean
 
@@ -129,10 +132,10 @@ spec:
   EOF
   }
 
-  function create_gradle_init() {
-    local init_script="${CI_PROJECT_DIR}/init-script.gradle"
+  function createGradleInit() {
+    local initScript="${CI_PROJECT_DIR}/init-script.gradle"
 
-    cat > $init_script <<'EOF'
+    cat > $initScript <<'EOF'
       import org.gradle.util.GradleVersion
 
       // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
@@ -501,10 +504,75 @@ spec:
 
   EOF
 
-    export DEVELOCITY_INIT_SCRIPT_PATH="${init_script}"
+    export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
   }
 
-  function inject_develocity_for_gradle() {
+  function createShortLivedToken() {
+    local allKeys="${GRADLE_ENTERPRISE_ACCESS_KEY:-${DEVELOCITY_ACCESS_KEY}}"
+    if [ -z "${allKeys}" ]
+    then
+      return 0
+    fi
+
+    local maxRetries=3
+    local retryInterval=1
+    local attempt=0
+
+    local serverUrl=${1}
+    local tokenUrl="${serverUrl}/api/auth/token"
+    local expiry="${2}"
+    local hostname=$(extractHostname "${serverUrl}")
+    local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
+
+    if [ ! -z "${accessKey}" ]
+    then
+      if [ ! -z "${expiry}" ]
+      then
+        tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
+      fi
+      while [ ${attempt} -le ${maxRetries} ]
+      do
+        local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+        local status_code=$(tail -n1 <<<$response)
+        local shortLivedToken=$(head -n -1 <<<$response)
+        if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+        then
+          export DEVELOCITY_ACCESS_KEY="${hostname}=${shortLivedToken}"
+          export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
+          return
+        elif [ "${status_code}" == "401" ]
+        then
+          >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+          return
+        else
+          ((attempt++))
+          sleep ${retryInterval}
+        fi
+      done
+    else
+      >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
+    fi
+  }
+
+  function extractHostname() {
+   local url=$1
+   echo "${url}" | cut -d'/' -f3 | cut -d':' -f1
+  }
+
+  function extractAccessKey() {
+   local allKeys=$1
+   local hostname=$2
+     key="${allKeys#*$hostname=}"    # Remove everything before the host name and '='
+     if [ "${key}" == "${allKeys}" ] # if nothing has changed, it's not a match
+     then
+       echo ""
+     else
+       key="${key%%;*}"              # Remove everything after the first ';'
+       echo "$key"
+     fi
+  }
+
+  function injectDevelocityForGradle() {
     export "DEVELOCITY_INJECTION_ENABLED=true"
     export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
     export "DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE=GitLab"
@@ -519,6 +587,7 @@ spec:
     export "GRADLE_PLUGIN_REPOSITORY_PASSWORD=$[[ inputs.gradlePluginRepositoryPassword ]]"
   }
 
-  create_gradle_report_init
-  create_gradle_init
-  inject_develocity_for_gradle
+  createGradleReportInit
+  createGradleInit
+  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
+  injectDevelocityForGradle

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -543,6 +543,8 @@ spec:
         elif [ "${status_code}" == "401" ]
         then
           >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+          export DEVELOCITY_ACCESS_KEY=""
+          export GRADLE_ENTERPRISE_ACCESS_KEY=""
           return
         else
           ((attempt++))
@@ -552,6 +554,8 @@ spec:
     else
       >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
     fi
+    export DEVELOCITY_ACCESS_KEY=""
+    export GRADLE_ENTERPRISE_ACCESS_KEY=""
   }
 
   function extractHostname() {

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -133,9 +133,9 @@ spec:
   }
 
   function createGradleInit() {
-    local init_script="${CI_PROJECT_DIR}/init-script.gradle"
+    local initScript="${CI_PROJECT_DIR}/init-script.gradle"
 
-    cat > $init_script <<'EOF'
+    cat > $initScript <<'EOF'
       import org.gradle.util.GradleVersion
 
       // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -514,66 +514,108 @@ spec:
       return 0
     fi
 
+    local serverUrl=${1}
+    local expiry="${2}"
+
+    local newAccessKey=""
+    if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
+    then
+      local hostname=$(extractHostname "${serverUrl}")
+      local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
+      local tokenUrl="${serverUrl}/api/auth/token"
+      if [ ! -z "${accessKey}" ]
+      then
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        if [ ! -z "${token}" ]
+        then
+          newAccessKey="${hostname}=${token}"
+        fi
+      else
+        >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
+      fi
+    else
+      local separator=";"
+      IFS="${separator}" read -ra pairs <<< "${allKeys}"
+      for pair in "${pairs[@]}"; do
+        IFS='=' read -r host key <<< "$pair"
+        local tokenUrl="https://${host}/api/auth/token"
+        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        if [ ! -z "${token}" ]
+        then
+          if [ -z "${newAccessKey}" ]
+          then
+            newAccessKey="${host}=${token}"
+          else
+            newAccessKey="${newAccessKey}${separator}${host}=${token}"
+          fi
+        fi
+      done
+    fi
+
+    export DEVELOCITY_ACCESS_KEY="${newAccessKey}"
+    export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
+  }
+
+  function singleKey() {
+    local allKeys=$1
+    local separator=";"
+    IFS="${separator}" read -ra pairs <<< "${allKeys}"
+    if [ "${#pairs[@]}" -eq 1 ]
+    then
+      echo "true"
+    else
+      echo "false"
+    fi
+  }
+
+  function extractHostname() {
+    local url=$1
+    echo "${url}" | cut -d'/' -f3 | cut -d':' -f1
+  }
+
+  function extractAccessKey() {
+    local allKeys=$1
+    local hostname=$2
+    key="${allKeys#*$hostname=}"    # Remove everything before the host name and '='
+    if [ "${key}" == "${allKeys}" ] # if nothing has changed, it's not a match
+    then
+      echo ""
+    else
+      key="${key%%;*}"              # Remove everything after the first ';'
+      echo "$key"
+    fi
+  }
+
+  function getShortLivedToken() {
+    local tokenUrl=$1
+    local expiry=$2
+    local accessKey=$3
     local maxRetries=3
     local retryInterval=1
     local attempt=0
 
-    local serverUrl=${1}
-    local tokenUrl="${serverUrl}/api/auth/token"
-    local expiry="${2}"
-    local hostname=$(extractHostname "${serverUrl}")
-    local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
-
-    if [ ! -z "${accessKey}" ]
+    if [ ! -z "${expiry}" ]
     then
-      if [ ! -z "${expiry}" ]
-      then
-        tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
-      fi
-      while [ ${attempt} -le ${maxRetries} ]
-      do
-        local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
-        local status_code=$(tail -n1 <<<$response)
-        local shortLivedToken=$(head -n -1 <<<$response)
-        if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
-        then
-          export DEVELOCITY_ACCESS_KEY="${hostname}=${shortLivedToken}"
-          export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
-          return
-        elif [ "${status_code}" == "401" ]
-        then
-          >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
-          export DEVELOCITY_ACCESS_KEY=""
-          export GRADLE_ENTERPRISE_ACCESS_KEY=""
-          return
-        else
-          ((attempt++))
-          sleep ${retryInterval}
-        fi
-      done
-    else
-      >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
+      tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
-    export DEVELOCITY_ACCESS_KEY=""
-    export GRADLE_ENTERPRISE_ACCESS_KEY=""
-  }
-
-  function extractHostname() {
-   local url=$1
-   echo "${url}" | cut -d'/' -f3 | cut -d':' -f1
-  }
-
-  function extractAccessKey() {
-   local allKeys=$1
-   local hostname=$2
-     key="${allKeys#*$hostname=}"    # Remove everything before the host name and '='
-     if [ "${key}" == "${allKeys}" ] # if nothing has changed, it's not a match
-     then
-       echo ""
-     else
-       key="${key%%;*}"              # Remove everything after the first ';'
-       echo "$key"
-     fi
+    while [ ${attempt} -le ${maxRetries} ]
+    do
+      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local status_code=$(tail -n1 <<< "${response}")
+      local shortLivedToken=$(head -n -1 <<< "${response}")
+      if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+      then
+        echo "${shortLivedToken}"
+        return
+      elif [ "${status_code}" == "401" ]
+      then
+        >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+        return
+      else
+        ((attempt++))
+        sleep ${retryInterval}
+      fi
+    done
   }
 
   function injectDevelocityForGradle() {

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -104,7 +104,7 @@ spec:
     then
       mavenOpts="-Dmaven.ext.class.path=${mavenExtClasspath} ${mavenOpts}"
     fi
-    if [[ ("${appliedCustomDv}" = "true" || "${appliedCustomCcud}" = "true") && "${enforceUrl}" = 'true' ]]
+    if [[ ("${appliedCustomDv}" = "true" || "${appliedCustomCcud}" = "true") && "${enforceUrl}" = "true" ]]
     then
       mavenOpts="${mavenOpts} -Dgradle.enterprise.url=${url} -Ddevelocity.url=${url}"
     elif [[ "${appliedCustomDv}" = "false" && "${appliedCustomCcud}" = "false" ]]
@@ -188,48 +188,58 @@ spec:
       return 0
     fi
 
-    local maxRetries=3
-    local retryInterval=1
-    local attempt=0
-
     local serverUrl=${1}
-    local tokenUrl="${serverUrl}/api/auth/token"
     local expiry="${2}"
-    local hostname=$(extractHostname "${serverUrl}")
-    local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
 
-    if [ ! -z "${accessKey}" ]
+    local newAccessKey=""
+    if [[ "${enforceUrl}" == "true" || $(singleKey allKeys) == "true" ]]
     then
-      if [ ! -z "${expiry}" ]
+      local hostname=$(extractHostname "${serverUrl}")
+      local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
+      local tokenUrl="${serverUrl}/api/auth/token"
+      if [ ! -z "${accessKey}" ]
       then
-        tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        if [ ! -z "${token}" ]
+        then
+          newAccessKey="${hostname}=${token}"
+        fi
+      else
+        >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
       fi
-      while [ ${attempt} -le ${maxRetries} ]
-      do
-        local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
-        local status_code=$(tail -n1 <<<$response)
-        local shortLivedToken=$(head -n -1 <<<$response)
-        if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+    else
+      local separator=";"
+      IFS="${separator}" read -ra pairs <<< "${allKeys}"
+      for pair in "${pairs[@]}"; do
+        IFS='=' read -r host key <<< "$pair"
+        local tokenUrl="https://${host}/api/auth/token"
+        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        if [ ! -z "${token}" ]
         then
-          export DEVELOCITY_ACCESS_KEY="${hostname}=${shortLivedToken}"
-          export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
-          return
-        elif [ "${status_code}" == "401" ]
-        then
-          >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
-          export DEVELOCITY_ACCESS_KEY=""
-          export GRADLE_ENTERPRISE_ACCESS_KEY=""
-          return
-        else
-          ((attempt++))
-          sleep ${retryInterval}
+          if [ -z "${newAccessKey}" ]
+          then
+            newAccessKey="${hostname}=${token}"
+          else
+            newAccessKey="${newAccessKey}${separator}${hostname}=${token}"
+          fi
         fi
       done
-    else
-      >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
     fi
-    export DEVELOCITY_ACCESS_KEY=""
-    export GRADLE_ENTERPRISE_ACCESS_KEY=""
+
+    export DEVELOCITY_ACCESS_KEY="${newAccessKey}"
+    export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
+  }
+
+  function singleKey() {
+    local allKeys=$1
+    local separator=";"
+    IFS="${separator}" read -ra pairs <<< "${allKeys}"
+    if [ "${#pairs[@]}" -eq 1 ]
+    then
+      echo "true"
+    else
+      echo "false"
+    fi
   }
 
   function extractHostname() {
@@ -248,6 +258,38 @@ spec:
         key="${key%%;*}"              # Remove everything after the first ';'
         echo "$key"
       fi
+  }
+
+  function getShortLivedToken() {
+    local tokenUrl=$1
+    local expiry=$2
+    local accessKey=$3
+    local maxRetries=3
+    local retryInterval=1
+    local attempt=0
+
+    if [ ! -z "${expiry}" ]
+    then
+      tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
+    fi
+    while [ ${attempt} -le ${maxRetries} ]
+    do
+      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local status_code=$(tail -n1 <<< "${response}")
+      local shortLivedToken=$(head -n -1 <<< "${response}")
+      if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+      then
+        echo "${shortLivedToken}"
+        return
+      elif [ "${status_code}" == "401" ]
+      then
+        >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+        return
+      else
+        ((attempt++))
+        sleep ${retryInterval}
+      fi
+    done
   }
   #functions-end
 

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -217,6 +217,8 @@ spec:
         elif [ "${status_code}" == "401" ]
         then
           >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+          export DEVELOCITY_ACCESS_KEY=""
+          export GRADLE_ENTERPRISE_ACCESS_KEY=""
           return
         else
           ((attempt++))
@@ -226,6 +228,8 @@ spec:
     else
       >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
     fi
+    export DEVELOCITY_ACCESS_KEY=""
+    export GRADLE_ENTERPRISE_ACCESS_KEY=""
   }
 
   function extractHostname() {

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -15,6 +15,9 @@ spec:
     # Allow untrusted server
     allowUntrustedServer:
       default: 'false'
+    # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
+    shortLivedTokensExpiry:
+      default: ''
     # Enforce URL
     enforceUrl:
       default: 'true'
@@ -35,6 +38,7 @@ spec:
   mavenRepo=$[[ inputs.mavenRepo ]]
   mavenExtensionVersion=$[[ inputs.mavenExtensionVersion ]]
   allowUntrustedServer=$[[ inputs.allowUntrustedServer ]]
+  shortLivedTokensExpiry=$[[ inputs.shortLivedTokensExpiry ]]
   enforceUrl=$[[ inputs.enforceUrl ]]
   captureFileFingerprints=$[[ inputs.captureFileFingerprints ]]
   customMavenExtensionCoordinates=$[[ inputs.mavenExtensionCustomCoordinates ]]
@@ -176,9 +180,75 @@ spec:
     local IFS=\>
     read -d \< elementName value
   }
+
+  function createShortLivedToken() {
+    local allKeys="${GRADLE_ENTERPRISE_ACCESS_KEY:-${DEVELOCITY_ACCESS_KEY}}"
+    if [ -z "${allKeys}" ]
+    then
+      return 0
+    fi
+
+    local maxRetries=3
+    local retryInterval=1
+    local attempt=0
+
+    local serverUrl=${1}
+    local tokenUrl="${serverUrl}/api/auth/token"
+    local expiry="${2}"
+    local hostname=$(extractHostname "${serverUrl}")
+    local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
+
+    if [ ! -z "${accessKey}" ]
+    then
+      if [ ! -z "${expiry}" ]
+      then
+        tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
+      fi
+      while [ ${attempt} -le ${maxRetries} ]
+      do
+        local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+        local status_code=$(tail -n1 <<<$response)
+        local shortLivedToken=$(head -n -1 <<<$response)
+        if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+        then
+          export DEVELOCITY_ACCESS_KEY="${hostname}=${shortLivedToken}"
+          export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
+          return
+        elif [ "${status_code}" == "401" ]
+        then
+          >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+          return
+        else
+          ((attempt++))
+          sleep ${retryInterval}
+        fi
+      done
+    else
+      >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
+    fi
+  }
+
+  function extractHostname() {
+    local url=$1
+    echo "${url}" | cut -d'/' -f3 | cut -d':' -f1
+  }
+
+  function extractAccessKey() {
+    local allKeys=$1
+    local hostname=$2
+      key="${allKeys#*$hostname=}"    # Remove everything before the host name and '='
+      if [ "${key}" == "${allKeys}" ] # if nothing has changed, it's not a match
+      then
+        echo ""
+      else
+        key="${key%%;*}"              # Remove everything after the first ';'
+        echo "$key"
+      fi
+  }
   #functions-end
 
   createTmp
   downloadDvCcudExt
   downloadDvMavenExt
+  createShortLivedToken "${url}" "${shortLivedTokensExpiry}"
   injectDevelocityForMaven "${PWD}"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -3,24 +3,21 @@ spec:
     # Develocity server URL
     url:
       default: 'https://scans.gradle.com'
-    # Maven remote repository to download extension jars from
-    mavenRepo:
-      default: 'https://repo1.maven.org/maven2'
-    # Develocity Maven extension version
-    mavenExtensionVersion:
-      default: '1.21.1'
-    # Common Custom User Data Maven extension version (see https://github.com/gradle/common-custom-user-data-maven-extension)
-    ccudMavenExtensionVersion:
-      default: '2.0'
     # Allow untrusted server
     allowUntrustedServer:
       default: 'false'
     # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
     shortLivedTokensExpiry:
       default: ''
-    # Enforce URL
-    enforceUrl:
-      default: 'true'
+    # Develocity Maven extension version
+    mavenExtensionVersion:
+      default: '1.21.1'
+    # Common Custom User Data Maven extension version (see https://github.com/gradle/common-custom-user-data-maven-extension)
+    ccudMavenExtensionVersion:
+      default: '2.0'
+    # Maven remote repository to download extension jars from
+    mavenRepo:
+      default: 'https://repo1.maven.org/maven2'
     # Capture file fingerprints, only set if no Develocity extension is already present
     captureFileFingerprints:
       default: 'true'
@@ -32,6 +29,9 @@ spec:
     # Expected format 'groupId:artifactId(:version)'
     ccudExtensionCustomCoordinates:
       default: ''
+    # Enforce URL
+    enforceUrl:
+      default: 'true'
 ---
 .injectDevelocityForMaven: |
   ccudMavenExtensionVersion=$[[ inputs.ccudMavenExtensionVersion ]]

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -34,7 +34,6 @@ spec:
       default: 'true'
 ---
 .injectDevelocityForMaven: |
-  set -x
   ccudMavenExtensionVersion=$[[ inputs.ccudMavenExtensionVersion ]]
   mavenRepo=$[[ inputs.mavenRepo ]]
   mavenExtensionVersion=$[[ inputs.mavenExtensionVersion ]]
@@ -193,7 +192,7 @@ spec:
     local expiry="${2}"
 
     local newAccessKey=""
-    if [[ "${enforceUrl}" == "true" || $(singleKey allKeys) == "true" ]]
+    if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
     then
       local hostname=$(extractHostname "${serverUrl}")
       local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
@@ -219,9 +218,9 @@ spec:
         then
           if [ -z "${newAccessKey}" ]
           then
-            newAccessKey="${hostname}=${token}"
+            newAccessKey="${host}=${token}"
           else
-            newAccessKey="${newAccessKey}${separator}${hostname}=${token}"
+            newAccessKey="${newAccessKey}${separator}${host}=${token}"
           fi
         fi
       done

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -34,6 +34,7 @@ spec:
       default: 'true'
 ---
 .injectDevelocityForMaven: |
+  set -x
   ccudMavenExtensionVersion=$[[ inputs.ccudMavenExtensionVersion ]]
   mavenRepo=$[[ inputs.mavenRepo ]]
   mavenExtensionVersion=$[[ inputs.mavenExtensionVersion ]]

--- a/test_maven.sh
+++ b/test_maven.sh
@@ -472,6 +472,32 @@ EOF
     assert "${MAVEN_OPTS}" "-Dmaven.ext.class.path=/path/to/common-custom-user-data-maven-extension.jar -Dgradle.scan.uploadInBackground=false -Ddevelocity.uploadInBackground=false -Dgradle.enterprise.allowUntrustedServer=false -Ddevelocity.allowUntrustedServer=false"
 }
 
+function test_extract_hostname() {
+    local hostname=$(extractHostname "http://some-dv-server.gradle.com")
+    assert "${hostname}" "some-dv-server.gradle.com"
+
+    hostname=$(extractHostname "http://some-dv-server.gradle.com/somepath")
+    assert "${hostname}" "some-dv-server.gradle.com"
+
+    hostname=$(extractHostname "http://192.168.1.10")
+    assert "${hostname}" "192.168.1.10"
+
+    hostname=$(extractHostname "http://192.168.1.10:5086")
+    assert "${hostname}" "192.168.1.10"
+
+    # we do not handle this case for now
+    hostname=$(extractHostname "not_a_url")
+    assert "${hostname}" "not_a_url"
+}
+
+function test_extract_access_key() {
+    local key=$(extractAccessKey "host1=key1;host2=key2;host3=key3" "host2")
+    assert "${key}" "key2"
+
+    key=$(extractAccessKey "host1=key1;host2=key2;host3=key3" "unknown")
+    assert "${key}" ""
+}
+
 function setupProject() {
     local projDir="$(mktemp -p ${buildDir} -d ge.XXXXXX)"
     local extDir="${projDir}/.mvn"
@@ -552,3 +578,5 @@ test_inject_capture_goal_input_files_true_old
 test_inject_capture_goal_input_files_true
 test_inject_capture_goal_input_files_false
 test_inject_capture_goal_input_files_existing_ext
+test_extract_hostname
+test_extract_access_key

--- a/test_maven.sh
+++ b/test_maven.sh
@@ -473,6 +473,7 @@ EOF
 }
 
 function test_extract_hostname() {
+    echo "test_extract_hostname"
     local hostname=$(extractHostname "http://some-dv-server.gradle.com")
     assert "${hostname}" "some-dv-server.gradle.com"
 
@@ -491,11 +492,21 @@ function test_extract_hostname() {
 }
 
 function test_extract_access_key() {
+    echo "test_extract_access_key"
     local key=$(extractAccessKey "host1=key1;host2=key2;host3=key3" "host2")
     assert "${key}" "key2"
 
     key=$(extractAccessKey "host1=key1;host2=key2;host3=key3" "unknown")
     assert "${key}" ""
+}
+
+function test_single_key() {
+    echo "test_single_key"
+    local key=$(singleKey "host1=key1")
+    assert "${key}" "true"
+
+    key=$(singleKey "host1=key1;host2=key2;host3=key3")
+    assert "${key}" "false"
 }
 
 function setupProject() {
@@ -580,3 +591,4 @@ test_inject_capture_goal_input_files_false
 test_inject_capture_goal_input_files_existing_ext
 test_extract_hostname
 test_extract_access_key
+test_single_key


### PR DESCRIPTION
Generate a short-lived token before each build and use it in the environment variable instead of the access key.
If the access key is not provided or it fails to get fetched, then the existing access key variable is cleared to avoid a leak.

A new input parameter is introduced to control the tokens expiry `shortLivedTokensExpiry`.
