### PR TITLE
Extract init-script contents out of 'develocity-gradle.yml'

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -7,7 +7,29 @@ env:
     GITLAB_PROJECT_ID: 48766853
 
 jobs:
+  verify-outputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run the build
+        run: ./build.sh
+
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v20
+        id: verify-changed-files
+    
+      - name: Fail if generated files are not up-to-date
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
+        run: |
+            echo "Generated files are not up-to-date: $CHANGED_FILES"
+            exit 1
+
   unit-test:
+    needs: verify-outputs
     name: Unit test scripts
     runs-on: ubuntu-latest
     steps:
@@ -16,7 +38,9 @@ jobs:
       - name: Unit test
         id: test
         run: ./test_maven.sh
+
   verification:
+    needs: verify-outputs
     name: Smoke test on GitLab
     runs-on: ubuntu-latest
     steps:

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+mkdir build
+
+# Copy the init-scripts to the build directory and indent them for inclusion in the 'develocity-gradle.yml' file.
+sed -e 's/^/      /' src/gradle/init-scripts/build-result-capture.init.gradle > build/build-result-capture.init.gradle
+sed -e 's/^/      /' src/gradle/init-scripts/develocity-injection.init.gradle > build/develocity-injection.init.gradle
+
 # Construct the combined 'develocity-gradle.yml' file from the template and the init-script contents.
 sed -e '/<<BUILD_RESULT_CAPTURE_INIT_GROOVY>>/{
-    r src/gradle/init-scripts/build-result-capture.init.gradle
+    r build/build-result-capture.init.gradle
     d
 }' -e '/<<DEVELOCITY_INJECTION_INIT_GRADLE>>/{
-    r src/gradle/init-scripts/develocity-injection.init.gradle
+    r build/develocity-injection.init.gradle
     d
 }' src/gradle/develocity-gradle.template.yml > develocity-gradle.yml

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir build
+mkdir -p build
 
 # Copy the init-scripts to the build directory and indent them for inclusion in the 'develocity-gradle.yml' file.
 sed -e 's/^/      /' src/gradle/init-scripts/build-result-capture.init.gradle > build/build-result-capture.init.gradle

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Construct the combined 'develocity-gradle.yml' file from the template and the init-script contents.
+sed -e '/<<BUILD_RESULT_CAPTURE_INIT_GROOVY>>/{
+    r src/gradle/init-scripts/build-result-capture.init.gradle
+    d
+}' -e '/<<DEVELOCITY_INJECTION_INIT_GRADLE>>/{
+    r src/gradle/init-scripts/develocity-injection.init.gradle
+    d
+}' src/gradle/develocity-gradle.template.yml > develocity-gradle.yml

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -45,23 +45,23 @@ spec:
     cat > $initScript <<'EOF'
       import org.gradle.util.GradleVersion
       import java.util.concurrent.atomic.AtomicBoolean
-
+      
       def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
       def BUILD_SCAN_EXTENSION = "buildScan"
       def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
       def DEVELOCITY_EXTENSION = "develocity"
       def GE_PLUGIN_ID = "com.gradle.enterprise"
       def GE_EXTENSION = "gradleEnterprise"
-
+      
       // Only run against root build. Do not run against included builds.
       def isTopLevelBuild = gradle.getParent() == null
       if (isTopLevelBuild) {
         def version = GradleVersion.current().baseVersion
-
+      
         def atLeastGradle3 = version >= GradleVersion.version("3.0")
         def atLeastGradle6 = version >= GradleVersion.version("6.0")
         def captureMarker = new AtomicBoolean(false)
-
+      
         if (atLeastGradle6) {
           settingsEvaluated { settings ->
             settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
@@ -88,7 +88,7 @@ spec:
           }
         }
       }
-
+      
       def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
         if (captureMarker.compareAndSet(false, true)) {
           buildScanExtension.with {
@@ -113,18 +113,18 @@ spec:
           }
         }
       }
-
+      
       class Report {
         List<Link> build_scans = []
-
+      
         void addLink(String url) {
           build_scans << new Link(url)
         }
       }
-
+      
       class Link {
         Map external_link
-
+      
         Link(String url) {
           external_link = [ 'label': url, 'url': url ]
         }
@@ -137,46 +137,46 @@ spec:
 
     cat > $initScript <<'EOF'
       import org.gradle.util.GradleVersion
-
+      
       // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
-
+      
       // conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
       initscript {
           def isTopLevelBuild = !gradle.parent
           if (!isTopLevelBuild) {
               return
           }
-
+      
           def getInputParam = { String name ->
               def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
               return System.getProperty(name) ?: System.getenv(envVarName)
           }
-
+      
           def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
           def initScriptName = buildscript.sourceFile.name
           if (requestedInitScriptName != initScriptName) {
               return
           }
-
+      
           // finish early if injection is disabled
           def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
           if (gradleInjectionEnabled != "true") {
               return
           }
-
+      
           def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
           def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
           def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
           def develocityPluginVersion = getInputParam('develocity.plugin.version')
           def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-
+      
           def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
           def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-
+      
           if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
               pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
               logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
-
+      
               repositories {
                   maven {
                       url pluginRepositoryUrl
@@ -193,7 +193,7 @@ spec:
                   }
               }
           }
-
+      
           dependencies {
               if (develocityPluginVersion) {
                   if (atLeastGradle5) {
@@ -206,49 +206,49 @@ spec:
                       classpath "com.gradle:build-scan-plugin:1.16"
                   }
               }
-
+      
               if (ccudPluginVersion && atLeastGradle4) {
                   classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
               }
           }
       }
-
+      
       def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
       def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-
+      
       def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
       def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-
+      
       def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
       def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-
+      
       def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
       def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
       def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
-
+      
       def isTopLevelBuild = !gradle.parent
       if (!isTopLevelBuild) {
           return
       }
-
+      
       def getInputParam = { String name ->
           def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
           return System.getProperty(name) ?: System.getenv(envVarName)
       }
-
+      
       def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
       def initScriptName = buildscript.sourceFile.name
       if (requestedInitScriptName != initScriptName) {
           logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
           return
       }
-
+      
       // finish early if injection is disabled
       def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
       if (gradleInjectionEnabled != "true") {
           return
       }
-
+      
       def develocityUrl = getInputParam('develocity.url')
       def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
       def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
@@ -259,30 +259,30 @@ spec:
       def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
       def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
       def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
-
+      
       def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
       def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
       def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
-
+      
       def dvOrGe = { def dvValue, def geValue ->
           if (shouldApplyDevelocityPlugin) {
               return dvValue instanceof Closure<?> ? dvValue() : dvValue
           }
           return geValue instanceof Closure<?> ? geValue() : geValue
       }
-
+      
       // finish early if configuration parameters passed in via system properties are not valid/supported
       if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
           logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
           return
       }
-
+      
       // register buildScanPublished listener and optionally apply the Develocity plugin
       if (GradleVersion.current() < GradleVersion.version('6.0')) {
           rootProject {
               buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
                   def resolutionResult = incoming.resolutionResult
-
+      
                   if (develocityPluginVersion) {
                       def scanPluginComponent = resolutionResult.allComponents.find {
                           it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
@@ -322,11 +322,11 @@ spec:
                               }
                           }
                       }
-
+      
                       if (develocityUrl && develocityEnforceUrl) {
                           logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                       }
-
+      
                       pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                           // Only execute if develocity plugin isn't applied.
                           if (gradle.rootProject.extensions.findByName("develocity")) return
@@ -336,13 +336,13 @@ spec:
                                   buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                               }
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
                               buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                           }
                       }
-
+      
                       pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
                           afterEvaluate {
                               if (develocityUrl && develocityEnforceUrl) {
@@ -350,14 +350,14 @@ spec:
                                   develocity.allowUntrustedServer = develocityAllowUntrustedServer
                               }
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                               develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                           }
                       }
                   }
-
+      
                   if (ccudPluginVersion && atLeastGradle4) {
                       def ccudPluginComponent = resolutionResult.allComponents.find {
                           it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
@@ -383,12 +383,12 @@ spec:
                               ext.allowUntrustedServer = develocityAllowUntrustedServer
                           }
                       }
-
+      
                       eachDevelocitySettingsExtension(settings) { ext ->
                           ext.buildScan.uploadInBackground = buildScanUploadInBackground
                           ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                       }
-
+      
                       eachDevelocitySettingsExtension(settings,
                           { develocity ->
                               logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -407,18 +407,18 @@ spec:
                           }
                       )
                   }
-
+      
                   if (develocityUrl && develocityEnforceUrl) {
                       logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                   }
-
+      
                   eachDevelocitySettingsExtension(settings,
                       { develocity ->
                           if (develocityUrl && develocityEnforceUrl) {
                               develocity.server = develocityUrl
                               develocity.allowUntrustedServer = develocityAllowUntrustedServer
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                               develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
@@ -429,7 +429,7 @@ spec:
                               gradleEnterprise.server = develocityUrl
                               gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
                               gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
@@ -437,7 +437,7 @@ spec:
                       }
                   )
               }
-
+      
               if (ccudPluginVersion) {
                   if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
                       logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
@@ -446,7 +446,7 @@ spec:
               }
           }
       }
-
+      
       void applyPluginExternally(def pluginManager, String pluginClassName) {
           def externallyApplied = 'develocity.externally-applied'
           def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
@@ -469,7 +469,7 @@ spec:
               }
           }
       }
-
+      
       /**
           * Apply the `dvAction` to all 'develocity' extensions.
           * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
@@ -478,7 +478,7 @@ spec:
       static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
           def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
           def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
-
+      
           def dvExtensions = settings.extensions.extensionsSchema.elements
               .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
               .collect { settings[it.name] }
@@ -491,11 +491,11 @@ spec:
               geExtensions.each(geAction)
           }
       }
-
+      
       static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
           GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
       }
-
+      
       static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
           !isAtLeast(versionUnderTest, referenceVersion)
       }

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -1,0 +1,192 @@
+spec:
+  inputs:
+    # Develocity server URL
+    url:
+      default: 'https://scans.gradle.com'
+    # Develocity Plugin version
+    # Allow untrusted server
+    allowUntrustedServer:
+      default: 'false'
+    # Short-lived tokens expiry in hours (if not set, default to 2 hours, should be between 1 and 24)
+    shortLivedTokensExpiry:
+      default: ''
+    gradlePluginVersion:
+      default: '3.17.2'
+    # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
+    ccudPluginVersion:
+      default: '2.0.1'
+    # Develocity Gradle plugin repository URL, defaults in the init script to https://plugins.gradle.org/m2
+    gradlePluginRepositoryUrl:
+      default: ''
+    # Develocity Gradle plugin repository username
+    gradlePluginRepositoryUsername:
+      default: ''
+    # Develocity Gradle plugin repository password, strongly advised to pass a protected and masked variable
+    gradlePluginRepositoryPassword:
+      default: ''
+    # Capture file fingerprints, only set if no Develocity plugin is already present
+    captureFileFingerprints:
+      default: 'true'
+    # Enforce the url over any defined locally to the project
+    enforceUrl:
+      default: 'false'
+
+---
+.build_scan_links_report:
+  artifacts:
+    reports:
+      annotations: $CI_PROJECT_DIR/build-scan-links.json
+
+.injectDevelocityForGradle: |
+  function createGradleReportInit() {
+    local initScript="${CI_PROJECT_DIR}/build-result-capture.init.groovy"
+    export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
+
+    cat > $initScript <<'EOF'
+<<BUILD_RESULT_CAPTURE_INIT_GROOVY>>
+  EOF
+  }
+
+  function createGradleInit() {
+    local initScript="${CI_PROJECT_DIR}/init-script.gradle"
+
+    cat > $initScript <<'EOF'
+<<DEVELOCITY_INJECTION_INIT_GRADLE>>
+
+      apply from: "${System.getenv('CI_PROJECT_DIR')}/build-result-capture.init.groovy"
+
+  EOF
+
+    export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
+  }
+
+  function createShortLivedToken() {
+    local allKeys="${GRADLE_ENTERPRISE_ACCESS_KEY:-${DEVELOCITY_ACCESS_KEY}}"
+    if [ -z "${allKeys}" ]
+    then
+      return 0
+    fi
+
+    local serverUrl=${1}
+    local expiry="${2}"
+
+    local newAccessKey=""
+    if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
+    then
+      local hostname=$(extractHostname "${serverUrl}")
+      local accessKey=$(extractAccessKey "${allKeys}" "${hostname}")
+      local tokenUrl="${serverUrl}/api/auth/token"
+      if [ ! -z "${accessKey}" ]
+      then
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        if [ ! -z "${token}" ]
+        then
+          newAccessKey="${hostname}=${token}"
+        fi
+      else
+        >&2 echo "Could not create short lived access token, no access key matching given Develocity server hostname ${hostname}"
+      fi
+    else
+      local separator=";"
+      IFS="${separator}" read -ra pairs <<< "${allKeys}"
+      for pair in "${pairs[@]}"; do
+        IFS='=' read -r host key <<< "$pair"
+        local tokenUrl="https://${host}/api/auth/token"
+        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        if [ ! -z "${token}" ]
+        then
+          if [ -z "${newAccessKey}" ]
+          then
+            newAccessKey="${host}=${token}"
+          else
+            newAccessKey="${newAccessKey}${separator}${host}=${token}"
+          fi
+        fi
+      done
+    fi
+
+    export DEVELOCITY_ACCESS_KEY="${newAccessKey}"
+    export GRADLE_ENTERPRISE_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY}"
+  }
+
+  function singleKey() {
+    local allKeys=$1
+    local separator=";"
+    IFS="${separator}" read -ra pairs <<< "${allKeys}"
+    if [ "${#pairs[@]}" -eq 1 ]
+    then
+      echo "true"
+    else
+      echo "false"
+    fi
+  }
+
+  function extractHostname() {
+    local url=$1
+    echo "${url}" | cut -d'/' -f3 | cut -d':' -f1
+  }
+
+  function extractAccessKey() {
+    local allKeys=$1
+    local hostname=$2
+    key="${allKeys#*$hostname=}"    # Remove everything before the host name and '='
+    if [ "${key}" == "${allKeys}" ] # if nothing has changed, it's not a match
+    then
+      echo ""
+    else
+      key="${key%%;*}"              # Remove everything after the first ';'
+      echo "$key"
+    fi
+  }
+
+  function getShortLivedToken() {
+    local tokenUrl=$1
+    local expiry=$2
+    local accessKey=$3
+    local maxRetries=3
+    local retryInterval=1
+    local attempt=0
+
+    if [ ! -z "${expiry}" ]
+    then
+      tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
+    fi
+    while [ ${attempt} -le ${maxRetries} ]
+    do
+      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local status_code=$(tail -n1 <<< "${response}")
+      local shortLivedToken=$(head -n -1 <<< "${response}")
+      if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
+      then
+        echo "${shortLivedToken}"
+        return
+      elif [ "${status_code}" == "401" ]
+      then
+        >&2 echo "Develocity short lived token request failed ${serverUrl} with status code 401"
+        return
+      else
+        ((attempt++))
+        sleep ${retryInterval}
+      fi
+    done
+  }
+
+  function injectDevelocityForGradle() {
+    export "DEVELOCITY_INJECTION_ENABLED=true"
+    export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
+    export "DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE=GitLab"
+    export "DEVELOCITY_URL=$[[ inputs.url ]]"
+    export "DEVELOCITY_PLUGIN_VERSION=$[[ inputs.gradlePluginVersion ]]"
+    export "DEVELOCITY_CCUD_PLUGIN_VERSION=$[[ inputs.ccudPluginVersion ]]"
+    export "DEVELOCITY_ALLOW_UNTRUSTED_SERVER=$[[ inputs.allowUntrustedServer ]]"
+    export "DEVELOCITY_ENFORCE_URL=$[[ inputs.enforceUrl ]]"
+    export "DEVELOCITY_CAPTURE_FILE_FINGERPRINTS=$[[ inputs.captureFileFingerprints ]]"
+    export "GRADLE_PLUGIN_REPOSITORY_URL=$[[ inputs.gradlePluginRepositoryUrl ]]"
+    export "GRADLE_PLUGIN_REPOSITORY_USERNAME=$[[ inputs.gradlePluginRepositoryUsername ]]"
+    export "GRADLE_PLUGIN_REPOSITORY_PASSWORD=$[[ inputs.gradlePluginRepositoryPassword ]]"
+  }
+
+  createGradleReportInit
+  createGradleInit
+  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
+  injectDevelocityForGradle

--- a/src/gradle/init-scripts/build-result-capture.init.gradle
+++ b/src/gradle/init-scripts/build-result-capture.init.gradle
@@ -1,0 +1,86 @@
+      import org.gradle.util.GradleVersion
+      import java.util.concurrent.atomic.AtomicBoolean
+
+      def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
+      def BUILD_SCAN_EXTENSION = "buildScan"
+      def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
+      def DEVELOCITY_EXTENSION = "develocity"
+      def GE_PLUGIN_ID = "com.gradle.enterprise"
+      def GE_EXTENSION = "gradleEnterprise"
+
+      // Only run against root build. Do not run against included builds.
+      def isTopLevelBuild = gradle.getParent() == null
+      if (isTopLevelBuild) {
+        def version = GradleVersion.current().baseVersion
+
+        def atLeastGradle3 = version >= GradleVersion.version("3.0")
+        def atLeastGradle6 = version >= GradleVersion.version("6.0")
+        def captureMarker = new AtomicBoolean(false)
+
+        if (atLeastGradle6) {
+          settingsEvaluated { settings ->
+            settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
+              // Only execute if develocity plugin isn't applied.
+              if (!settings.extensions.findByName(DEVELOCITY_EXTENSION)) {
+                captureUsingBuildScanPublished(settings.extensions[GE_EXTENSION].buildScan, settings.rootProject, captureMarker)
+              }
+            }
+            settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+              captureUsingBuildScanPublished(settings.extensions[DEVELOCITY_EXTENSION].buildScan, settings.rootProject, captureMarker)
+            }
+          }
+        } else if (atLeastGradle3) {
+          projectsEvaluated { gradle ->
+            gradle.rootProject.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+              // Only execute if develocity plugin isn't applied.
+              if (!gradle.rootProject.extensions.findByName(DEVELOCITY_EXTENSION)) {
+                captureUsingBuildScanPublished(gradle.rootProject.extensions[BUILD_SCAN_EXTENSION], gradle.rootProject, captureMarker)
+              }
+            }
+            gradle.rootProject.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+              captureUsingBuildScanPublished(gradle.rootProject.extensions[DEVELOCITY_EXTENSION].buildScan, gradle.rootProject, captureMarker)
+            }
+          }
+        }
+      }
+
+      def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
+        if (captureMarker.compareAndSet(false, true)) {
+          buildScanExtension.with {
+            buildScanPublished { buildScan ->
+              if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
+                def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
+                def report
+                // This might have been created by a previous Gradle invocation in the same GitLab job
+                // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
+                if (reportFile.exists()) {
+                  report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
+                } else {
+                  report = new Report()
+                }
+                report.addLink("${buildScan.buildScanUri}")
+                def generator = new groovy.json.JsonGenerator.Options()
+                  .excludeFieldsByName('contentHash', 'originalClassName')
+                  .build()
+                reportFile.text = generator.toJson(report)
+              }
+            }
+          }
+        }
+      }
+
+      class Report {
+        List<Link> build_scans = []
+
+        void addLink(String url) {
+          build_scans << new Link(url)
+        }
+      }
+
+      class Link {
+        Map external_link
+
+        Link(String url) {
+          external_link = [ 'label': url, 'url': url ]
+        }
+      }

--- a/src/gradle/init-scripts/build-result-capture.init.gradle
+++ b/src/gradle/init-scripts/build-result-capture.init.gradle
@@ -1,86 +1,86 @@
-      import org.gradle.util.GradleVersion
-      import java.util.concurrent.atomic.AtomicBoolean
+import org.gradle.util.GradleVersion
+import java.util.concurrent.atomic.AtomicBoolean
 
-      def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
-      def BUILD_SCAN_EXTENSION = "buildScan"
-      def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
-      def DEVELOCITY_EXTENSION = "develocity"
-      def GE_PLUGIN_ID = "com.gradle.enterprise"
-      def GE_EXTENSION = "gradleEnterprise"
+def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
+def BUILD_SCAN_EXTENSION = "buildScan"
+def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
+def DEVELOCITY_EXTENSION = "develocity"
+def GE_PLUGIN_ID = "com.gradle.enterprise"
+def GE_EXTENSION = "gradleEnterprise"
 
-      // Only run against root build. Do not run against included builds.
-      def isTopLevelBuild = gradle.getParent() == null
-      if (isTopLevelBuild) {
-        def version = GradleVersion.current().baseVersion
+// Only run against root build. Do not run against included builds.
+def isTopLevelBuild = gradle.getParent() == null
+if (isTopLevelBuild) {
+  def version = GradleVersion.current().baseVersion
 
-        def atLeastGradle3 = version >= GradleVersion.version("3.0")
-        def atLeastGradle6 = version >= GradleVersion.version("6.0")
-        def captureMarker = new AtomicBoolean(false)
+  def atLeastGradle3 = version >= GradleVersion.version("3.0")
+  def atLeastGradle6 = version >= GradleVersion.version("6.0")
+  def captureMarker = new AtomicBoolean(false)
 
-        if (atLeastGradle6) {
-          settingsEvaluated { settings ->
-            settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
-              // Only execute if develocity plugin isn't applied.
-              if (!settings.extensions.findByName(DEVELOCITY_EXTENSION)) {
-                captureUsingBuildScanPublished(settings.extensions[GE_EXTENSION].buildScan, settings.rootProject, captureMarker)
-              }
-            }
-            settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-              captureUsingBuildScanPublished(settings.extensions[DEVELOCITY_EXTENSION].buildScan, settings.rootProject, captureMarker)
-            }
+  if (atLeastGradle6) {
+    settingsEvaluated { settings ->
+      settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
+        // Only execute if develocity plugin isn't applied.
+        if (!settings.extensions.findByName(DEVELOCITY_EXTENSION)) {
+          captureUsingBuildScanPublished(settings.extensions[GE_EXTENSION].buildScan, settings.rootProject, captureMarker)
+        }
+      }
+      settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+        captureUsingBuildScanPublished(settings.extensions[DEVELOCITY_EXTENSION].buildScan, settings.rootProject, captureMarker)
+      }
+    }
+  } else if (atLeastGradle3) {
+    projectsEvaluated { gradle ->
+      gradle.rootProject.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+        // Only execute if develocity plugin isn't applied.
+        if (!gradle.rootProject.extensions.findByName(DEVELOCITY_EXTENSION)) {
+          captureUsingBuildScanPublished(gradle.rootProject.extensions[BUILD_SCAN_EXTENSION], gradle.rootProject, captureMarker)
+        }
+      }
+      gradle.rootProject.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+        captureUsingBuildScanPublished(gradle.rootProject.extensions[DEVELOCITY_EXTENSION].buildScan, gradle.rootProject, captureMarker)
+      }
+    }
+  }
+}
+
+def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
+  if (captureMarker.compareAndSet(false, true)) {
+    buildScanExtension.with {
+      buildScanPublished { buildScan ->
+        if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
+          def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
+          def report
+          // This might have been created by a previous Gradle invocation in the same GitLab job
+          // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
+          if (reportFile.exists()) {
+            report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
+          } else {
+            report = new Report()
           }
-        } else if (atLeastGradle3) {
-          projectsEvaluated { gradle ->
-            gradle.rootProject.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-              // Only execute if develocity plugin isn't applied.
-              if (!gradle.rootProject.extensions.findByName(DEVELOCITY_EXTENSION)) {
-                captureUsingBuildScanPublished(gradle.rootProject.extensions[BUILD_SCAN_EXTENSION], gradle.rootProject, captureMarker)
-              }
-            }
-            gradle.rootProject.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-              captureUsingBuildScanPublished(gradle.rootProject.extensions[DEVELOCITY_EXTENSION].buildScan, gradle.rootProject, captureMarker)
-            }
-          }
+          report.addLink("${buildScan.buildScanUri}")
+          def generator = new groovy.json.JsonGenerator.Options()
+            .excludeFieldsByName('contentHash', 'originalClassName')
+            .build()
+          reportFile.text = generator.toJson(report)
         }
       }
+    }
+  }
+}
 
-      def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
-        if (captureMarker.compareAndSet(false, true)) {
-          buildScanExtension.with {
-            buildScanPublished { buildScan ->
-              if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
-                def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
-                def report
-                // This might have been created by a previous Gradle invocation in the same GitLab job
-                // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
-                if (reportFile.exists()) {
-                  report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
-                } else {
-                  report = new Report()
-                }
-                report.addLink("${buildScan.buildScanUri}")
-                def generator = new groovy.json.JsonGenerator.Options()
-                  .excludeFieldsByName('contentHash', 'originalClassName')
-                  .build()
-                reportFile.text = generator.toJson(report)
-              }
-            }
-          }
-        }
-      }
+class Report {
+  List<Link> build_scans = []
 
-      class Report {
-        List<Link> build_scans = []
+  void addLink(String url) {
+    build_scans << new Link(url)
+  }
+}
 
-        void addLink(String url) {
-          build_scans << new Link(url)
-        }
-      }
+class Link {
+  Map external_link
 
-      class Link {
-        Map external_link
-
-        Link(String url) {
-          external_link = [ 'label': url, 'url': url ]
-        }
-      }
+  Link(String url) {
+    external_link = [ 'label': url, 'url': url ]
+  }
+}

--- a/src/gradle/init-scripts/develocity-injection.init.gradle
+++ b/src/gradle/init-scripts/develocity-injection.init.gradle
@@ -1,363 +1,363 @@
-      import org.gradle.util.GradleVersion
+import org.gradle.util.GradleVersion
 
-      // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
+// note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
 
-      // conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
-      initscript {
-          def isTopLevelBuild = !gradle.parent
-          if (!isTopLevelBuild) {
-              return
-          }
+// conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
+initscript {
+    def isTopLevelBuild = !gradle.parent
+    if (!isTopLevelBuild) {
+        return
+    }
 
-          def getInputParam = { String name ->
-              def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-              return System.getProperty(name) ?: System.getenv(envVarName)
-          }
+    def getInputParam = { String name ->
+        def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+        return System.getProperty(name) ?: System.getenv(envVarName)
+    }
 
-          def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
-          def initScriptName = buildscript.sourceFile.name
-          if (requestedInitScriptName != initScriptName) {
-              return
-          }
+    def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+    def initScriptName = buildscript.sourceFile.name
+    if (requestedInitScriptName != initScriptName) {
+        return
+    }
 
-          // finish early if injection is disabled
-          def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-          if (gradleInjectionEnabled != "true") {
-              return
-          }
+    // finish early if injection is disabled
+    def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+    if (gradleInjectionEnabled != "true") {
+        return
+    }
 
-          def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
-          def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
-          def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
-          def develocityPluginVersion = getInputParam('develocity.plugin.version')
-          def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+    def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
+    def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
+    def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
+    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 
-          def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-          def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
-          if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
-              pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
-              logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
+    if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
+        pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
+        logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
 
-              repositories {
-                  maven {
-                      url pluginRepositoryUrl
-                      if (pluginRepositoryUsername && pluginRepositoryPassword) {
-                          logger.lifecycle("Using credentials for plugin repository")
-                          credentials {
-                              username(pluginRepositoryUsername)
-                              password(pluginRepositoryPassword)
-                          }
-                          authentication {
-                              basic(BasicAuthentication)
-                          }
-                      }
-                  }
-              }
-          }
+        repositories {
+            maven {
+                url pluginRepositoryUrl
+                if (pluginRepositoryUsername && pluginRepositoryPassword) {
+                    logger.lifecycle("Using credentials for plugin repository")
+                    credentials {
+                        username(pluginRepositoryUsername)
+                        password(pluginRepositoryPassword)
+                    }
+                    authentication {
+                        basic(BasicAuthentication)
+                    }
+                }
+            }
+        }
+    }
 
-          dependencies {
-              if (develocityPluginVersion) {
-                  if (atLeastGradle5) {
-                      if (GradleVersion.version(develocityPluginVersion) >= GradleVersion.version("3.17")) {
-                          classpath "com.gradle:develocity-gradle-plugin:$develocityPluginVersion"
-                      } else {
-                          classpath "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion"
-                      }
-                  } else {
-                      classpath "com.gradle:build-scan-plugin:1.16"
-                  }
-              }
+    dependencies {
+        if (develocityPluginVersion) {
+            if (atLeastGradle5) {
+                if (GradleVersion.version(develocityPluginVersion) >= GradleVersion.version("3.17")) {
+                    classpath "com.gradle:develocity-gradle-plugin:$develocityPluginVersion"
+                } else {
+                    classpath "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion"
+                }
+            } else {
+                classpath "com.gradle:build-scan-plugin:1.16"
+            }
+        }
 
-              if (ccudPluginVersion && atLeastGradle4) {
-                  classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
-              }
-          }
-      }
+        if (ccudPluginVersion && atLeastGradle4) {
+            classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
+        }
+    }
+}
 
-      def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-      def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
+def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-      def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
-      def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 
-      def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-      def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
 
-      def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-      def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-      def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 
-      def isTopLevelBuild = !gradle.parent
-      if (!isTopLevelBuild) {
-          return
-      }
+def isTopLevelBuild = !gradle.parent
+if (!isTopLevelBuild) {
+    return
+}
 
-      def getInputParam = { String name ->
-          def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
-          return System.getProperty(name) ?: System.getenv(envVarName)
-      }
+def getInputParam = { String name ->
+    def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+    return System.getProperty(name) ?: System.getenv(envVarName)
+}
 
-      def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
-      def initScriptName = buildscript.sourceFile.name
-      if (requestedInitScriptName != initScriptName) {
-          logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
-          return
-      }
+def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+def initScriptName = buildscript.sourceFile.name
+if (requestedInitScriptName != initScriptName) {
+    logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
+    return
+}
 
-      // finish early if injection is disabled
-      def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-      if (gradleInjectionEnabled != "true") {
-          return
-      }
+// finish early if injection is disabled
+def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+if (gradleInjectionEnabled != "true") {
+    return
+}
 
-      def develocityUrl = getInputParam('develocity.url')
-      def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-      def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-      def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-      def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
-      def develocityPluginVersion = getInputParam('develocity.plugin.version')
-      def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-      def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-      def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-      def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+def develocityUrl = getInputParam('develocity.url')
+def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+def develocityPluginVersion = getInputParam('develocity.plugin.version')
+def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
 
-      def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-      def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-      def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
 
-      def dvOrGe = { def dvValue, def geValue ->
-          if (shouldApplyDevelocityPlugin) {
-              return dvValue instanceof Closure<?> ? dvValue() : dvValue
-          }
-          return geValue instanceof Closure<?> ? geValue() : geValue
-      }
+def dvOrGe = { def dvValue, def geValue ->
+    if (shouldApplyDevelocityPlugin) {
+        return dvValue instanceof Closure<?> ? dvValue() : dvValue
+    }
+    return geValue instanceof Closure<?> ? geValue() : geValue
+}
 
-      // finish early if configuration parameters passed in via system properties are not valid/supported
-      if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-          logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
-          return
-      }
+// finish early if configuration parameters passed in via system properties are not valid/supported
+if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+    logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+    return
+}
 
-      // register buildScanPublished listener and optionally apply the Develocity plugin
-      if (GradleVersion.current() < GradleVersion.version('6.0')) {
-          rootProject {
-              buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
-                  def resolutionResult = incoming.resolutionResult
+// register buildScanPublished listener and optionally apply the Develocity plugin
+if (GradleVersion.current() < GradleVersion.version('6.0')) {
+    rootProject {
+        buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+            def resolutionResult = incoming.resolutionResult
 
-                  if (develocityPluginVersion) {
-                      def scanPluginComponent = resolutionResult.allComponents.find {
-                          it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
-                      }
-                      if (!scanPluginComponent) {
-                          def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                          logger.lifecycle("Applying $pluginClass via init script")
-                          applyPluginExternally(pluginManager, pluginClass)
-                          def rootExtension = dvOrGe(
-                                  { develocity },
-                                  { buildScan }
-                          )
-                          def buildScanExtension = dvOrGe(
-                                  { rootExtension.buildScan },
-                                  { rootExtension }
-                          )
-                          if (develocityUrl) {
-                              logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              rootExtension.server = develocityUrl
-                              rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
-                          if (!shouldApplyDevelocityPlugin) {
-                              // Develocity plugin publishes scans by default
-                              buildScanExtension.publishAlways()
-                          }
-                          // uploadInBackground not available for build-scan-plugin 1.16
-                          if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
-                          buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                          if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              if (isAtLeast(develocityPluginVersion, '3.17')) {
-                                  buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                              } else if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                  buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
-                              } else {
-                                  buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
-                              }
-                          }
-                      }
+            if (develocityPluginVersion) {
+                def scanPluginComponent = resolutionResult.allComponents.find {
+                    it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
+                }
+                if (!scanPluginComponent) {
+                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                    logger.lifecycle("Applying $pluginClass via init script")
+                    applyPluginExternally(pluginManager, pluginClass)
+                    def rootExtension = dvOrGe(
+                            { develocity },
+                            { buildScan }
+                    )
+                    def buildScanExtension = dvOrGe(
+                            { rootExtension.buildScan },
+                            { rootExtension }
+                    )
+                    if (develocityUrl) {
+                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        rootExtension.server = develocityUrl
+                        rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
+                    if (!shouldApplyDevelocityPlugin) {
+                        // Develocity plugin publishes scans by default
+                        buildScanExtension.publishAlways()
+                    }
+                    // uploadInBackground not available for build-scan-plugin 1.16
+                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                    if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        if (isAtLeast(develocityPluginVersion, '3.17')) {
+                            buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                        } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                            buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                        } else {
+                            buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                        }
+                    }
+                }
 
-                      if (develocityUrl && develocityEnforceUrl) {
-                          logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                      }
+                if (develocityUrl && develocityEnforceUrl) {
+                    logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                }
 
-                      pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                          // Only execute if develocity plugin isn't applied.
-                          if (gradle.rootProject.extensions.findByName("develocity")) return
-                          afterEvaluate {
-                              if (develocityUrl && develocityEnforceUrl) {
-                                  buildScan.server = develocityUrl
-                                  buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                              }
-                          }
+                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                    // Only execute if develocity plugin isn't applied.
+                    if (gradle.rootProject.extensions.findByName("develocity")) return
+                    afterEvaluate {
+                        if (develocityUrl && develocityEnforceUrl) {
+                            buildScan.server = develocityUrl
+                            buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
 
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                              buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                          }
-                      }
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                        buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+                }
 
-                      pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                          afterEvaluate {
-                              if (develocityUrl && develocityEnforceUrl) {
-                                  develocity.server = develocityUrl
-                                  develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                              }
-                          }
+                pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                    afterEvaluate {
+                        if (develocityUrl && develocityEnforceUrl) {
+                            develocity.server = develocityUrl
+                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
 
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                          }
-                      }
-                  }
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                    }
+                }
+            }
 
-                  if (ccudPluginVersion && atLeastGradle4) {
-                      def ccudPluginComponent = resolutionResult.allComponents.find {
-                          it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
-                      }
-                      if (!ccudPluginComponent) {
-                          logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                          pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                      }
-                  }
-              }
-          }
-      } else {
-          gradle.settingsEvaluated { settings ->
-              if (develocityPluginVersion) {
-                  if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                      def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                      logger.lifecycle("Applying $pluginClass via init script")
-                      applyPluginExternally(settings.pluginManager, pluginClass)
-                      if (develocityUrl) {
-                          logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                          eachDevelocitySettingsExtension(settings) { ext ->
-                              ext.server = develocityUrl
-                              ext.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
-                      }
+            if (ccudPluginVersion && atLeastGradle4) {
+                def ccudPluginComponent = resolutionResult.allComponents.find {
+                    it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                }
+                if (!ccudPluginComponent) {
+                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                    pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                }
+            }
+        }
+    }
+} else {
+    gradle.settingsEvaluated { settings ->
+        if (develocityPluginVersion) {
+            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                logger.lifecycle("Applying $pluginClass via init script")
+                applyPluginExternally(settings.pluginManager, pluginClass)
+                if (develocityUrl) {
+                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                    eachDevelocitySettingsExtension(settings) { ext ->
+                        ext.server = develocityUrl
+                        ext.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
+                }
 
-                      eachDevelocitySettingsExtension(settings) { ext ->
-                          ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                          ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                      }
+                eachDevelocitySettingsExtension(settings) { ext ->
+                    ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                }
 
-                      eachDevelocitySettingsExtension(settings,
-                          { develocity ->
-                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
-                          },
-                          { gradleEnterprise ->
-                              gradleEnterprise.buildScan.publishAlways()
-                              if (isAtLeast(develocityPluginVersion, '2.1')) {
-                                  logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                                  if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                      gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                                  } else {
-                                      gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                                  }
-                              }
-                          }
-                      )
-                  }
+                eachDevelocitySettingsExtension(settings,
+                    { develocity ->
+                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                    },
+                    { gradleEnterprise ->
+                        gradleEnterprise.buildScan.publishAlways()
+                        if (isAtLeast(develocityPluginVersion, '2.1')) {
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                            } else {
+                                gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                            }
+                        }
+                    }
+                )
+            }
 
-                  if (develocityUrl && develocityEnforceUrl) {
-                      logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                  }
+            if (develocityUrl && develocityEnforceUrl) {
+                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+            }
 
-                  eachDevelocitySettingsExtension(settings,
-                      { develocity ->
-                          if (develocityUrl && develocityEnforceUrl) {
-                              develocity.server = develocityUrl
-                              develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
+            eachDevelocitySettingsExtension(settings,
+                { develocity ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        develocity.server = develocityUrl
+                        develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
 
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                          }
-                      },
-                      { gradleEnterprise ->
-                          if (develocityUrl && develocityEnforceUrl) {
-                              gradleEnterprise.server = develocityUrl
-                              gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                    }
+                },
+                { gradleEnterprise ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        gradleEnterprise.server = develocityUrl
+                        gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
 
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                              gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                          }
-                      }
-                  )
-              }
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                        gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+                }
+            )
+        }
 
-              if (ccudPluginVersion) {
-                  if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                      logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                      settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                  }
-              }
-          }
-      }
+        if (ccudPluginVersion) {
+            if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+            }
+        }
+    }
+}
 
-      void applyPluginExternally(def pluginManager, String pluginClassName) {
-          def externallyApplied = 'develocity.externally-applied'
-          def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
-          def oldValue = System.getProperty(externallyApplied)
-          def oldValueDeprecated = System.getProperty(externallyAppliedDeprecated)
-          System.setProperty(externallyApplied, 'true')
-          System.setProperty(externallyAppliedDeprecated, 'true')
-          try {
-              pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
-          } finally {
-              if (oldValue == null) {
-                  System.clearProperty(externallyApplied)
-              } else {
-                  System.setProperty(externallyApplied, oldValue)
-              }
-              if (oldValueDeprecated == null) {
-                  System.clearProperty(externallyAppliedDeprecated)
-              } else {
-                  System.setProperty(externallyAppliedDeprecated, oldValueDeprecated)
-              }
-          }
-      }
+void applyPluginExternally(def pluginManager, String pluginClassName) {
+    def externallyApplied = 'develocity.externally-applied'
+    def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
+    def oldValue = System.getProperty(externallyApplied)
+    def oldValueDeprecated = System.getProperty(externallyAppliedDeprecated)
+    System.setProperty(externallyApplied, 'true')
+    System.setProperty(externallyAppliedDeprecated, 'true')
+    try {
+        pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
+    } finally {
+        if (oldValue == null) {
+            System.clearProperty(externallyApplied)
+        } else {
+            System.setProperty(externallyApplied, oldValue)
+        }
+        if (oldValueDeprecated == null) {
+            System.clearProperty(externallyAppliedDeprecated)
+        } else {
+            System.setProperty(externallyAppliedDeprecated, oldValueDeprecated)
+        }
+    }
+}
 
-      /**
-          * Apply the `dvAction` to all 'develocity' extensions.
-          * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
-          * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
-          */
-      static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
-          def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
-          def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
+/**
+    * Apply the `dvAction` to all 'develocity' extensions.
+    * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
+    * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+    */
+static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
+    def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+    def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
 
-          def dvExtensions = settings.extensions.extensionsSchema.elements
-              .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
-              .collect { settings[it.name] }
-          if (!dvExtensions.empty) {
-              dvExtensions.each(dvAction)
-          } else {
-              def geExtensions = settings.extensions.extensionsSchema.elements
-                  .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
-                  .collect { settings[it.name] }
-              geExtensions.each(geAction)
-          }
-      }
+    def dvExtensions = settings.extensions.extensionsSchema.elements
+        .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
+        .collect { settings[it.name] }
+    if (!dvExtensions.empty) {
+        dvExtensions.each(dvAction)
+    } else {
+        def geExtensions = settings.extensions.extensionsSchema.elements
+            .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
+            .collect { settings[it.name] }
+        geExtensions.each(geAction)
+    }
+}
 
-      static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
-          GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
-      }
+static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
+    GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
+}
 
-      static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
-          !isAtLeast(versionUnderTest, referenceVersion)
-      }
+static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
+    !isAtLeast(versionUnderTest, referenceVersion)
+}

--- a/src/gradle/init-scripts/develocity-injection.init.gradle
+++ b/src/gradle/init-scripts/develocity-injection.init.gradle
@@ -1,0 +1,363 @@
+      import org.gradle.util.GradleVersion
+
+      // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
+
+      // conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
+      initscript {
+          def isTopLevelBuild = !gradle.parent
+          if (!isTopLevelBuild) {
+              return
+          }
+
+          def getInputParam = { String name ->
+              def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+              return System.getProperty(name) ?: System.getenv(envVarName)
+          }
+
+          def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+          def initScriptName = buildscript.sourceFile.name
+          if (requestedInitScriptName != initScriptName) {
+              return
+          }
+
+          // finish early if injection is disabled
+          def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+          if (gradleInjectionEnabled != "true") {
+              return
+          }
+
+          def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
+          def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
+          def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+          def develocityPluginVersion = getInputParam('develocity.plugin.version')
+          def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+
+          def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+          def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+
+          if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
+              pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
+              logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
+
+              repositories {
+                  maven {
+                      url pluginRepositoryUrl
+                      if (pluginRepositoryUsername && pluginRepositoryPassword) {
+                          logger.lifecycle("Using credentials for plugin repository")
+                          credentials {
+                              username(pluginRepositoryUsername)
+                              password(pluginRepositoryPassword)
+                          }
+                          authentication {
+                              basic(BasicAuthentication)
+                          }
+                      }
+                  }
+              }
+          }
+
+          dependencies {
+              if (develocityPluginVersion) {
+                  if (atLeastGradle5) {
+                      if (GradleVersion.version(develocityPluginVersion) >= GradleVersion.version("3.17")) {
+                          classpath "com.gradle:develocity-gradle-plugin:$develocityPluginVersion"
+                      } else {
+                          classpath "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion"
+                      }
+                  } else {
+                      classpath "com.gradle:build-scan-plugin:1.16"
+                  }
+              }
+
+              if (ccudPluginVersion && atLeastGradle4) {
+                  classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
+              }
+          }
+      }
+
+      def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+      def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
+
+      def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+      def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+
+      def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+      def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+
+      def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+      def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+      def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
+      def isTopLevelBuild = !gradle.parent
+      if (!isTopLevelBuild) {
+          return
+      }
+
+      def getInputParam = { String name ->
+          def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+          return System.getProperty(name) ?: System.getenv(envVarName)
+      }
+
+      def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+      def initScriptName = buildscript.sourceFile.name
+      if (requestedInitScriptName != initScriptName) {
+          logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
+          return
+      }
+
+      // finish early if injection is disabled
+      def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+      if (gradleInjectionEnabled != "true") {
+          return
+      }
+
+      def develocityUrl = getInputParam('develocity.url')
+      def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+      def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+      def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+      def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+      def develocityPluginVersion = getInputParam('develocity.plugin.version')
+      def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+      def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+      def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+      def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+
+      def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+      def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+      def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+
+      def dvOrGe = { def dvValue, def geValue ->
+          if (shouldApplyDevelocityPlugin) {
+              return dvValue instanceof Closure<?> ? dvValue() : dvValue
+          }
+          return geValue instanceof Closure<?> ? geValue() : geValue
+      }
+
+      // finish early if configuration parameters passed in via system properties are not valid/supported
+      if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+          logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+          return
+      }
+
+      // register buildScanPublished listener and optionally apply the Develocity plugin
+      if (GradleVersion.current() < GradleVersion.version('6.0')) {
+          rootProject {
+              buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+                  def resolutionResult = incoming.resolutionResult
+
+                  if (develocityPluginVersion) {
+                      def scanPluginComponent = resolutionResult.allComponents.find {
+                          it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
+                      }
+                      if (!scanPluginComponent) {
+                          def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                          logger.lifecycle("Applying $pluginClass via init script")
+                          applyPluginExternally(pluginManager, pluginClass)
+                          def rootExtension = dvOrGe(
+                                  { develocity },
+                                  { buildScan }
+                          )
+                          def buildScanExtension = dvOrGe(
+                                  { rootExtension.buildScan },
+                                  { rootExtension }
+                          )
+                          if (develocityUrl) {
+                              logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                              rootExtension.server = develocityUrl
+                              rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                          }
+                          if (!shouldApplyDevelocityPlugin) {
+                              // Develocity plugin publishes scans by default
+                              buildScanExtension.publishAlways()
+                          }
+                          // uploadInBackground not available for build-scan-plugin 1.16
+                          if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                          buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                          if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                              if (isAtLeast(develocityPluginVersion, '3.17')) {
+                                  buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                              } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                  buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                              } else {
+                                  buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                              }
+                          }
+                      }
+
+                      if (develocityUrl && develocityEnforceUrl) {
+                          logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                      }
+
+                      pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                          // Only execute if develocity plugin isn't applied.
+                          if (gradle.rootProject.extensions.findByName("develocity")) return
+                          afterEvaluate {
+                              if (develocityUrl && develocityEnforceUrl) {
+                                  buildScan.server = develocityUrl
+                                  buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                              }
+                          }
+
+                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                              buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                              buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                          }
+                      }
+
+                      pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                          afterEvaluate {
+                              if (develocityUrl && develocityEnforceUrl) {
+                                  develocity.server = develocityUrl
+                                  develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                              }
+                          }
+
+                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                          }
+                      }
+                  }
+
+                  if (ccudPluginVersion && atLeastGradle4) {
+                      def ccudPluginComponent = resolutionResult.allComponents.find {
+                          it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                      }
+                      if (!ccudPluginComponent) {
+                          logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                          pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                      }
+                  }
+              }
+          }
+      } else {
+          gradle.settingsEvaluated { settings ->
+              if (develocityPluginVersion) {
+                  if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                      def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                      logger.lifecycle("Applying $pluginClass via init script")
+                      applyPluginExternally(settings.pluginManager, pluginClass)
+                      if (develocityUrl) {
+                          logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                          eachDevelocitySettingsExtension(settings) { ext ->
+                              ext.server = develocityUrl
+                              ext.allowUntrustedServer = develocityAllowUntrustedServer
+                          }
+                      }
+
+                      eachDevelocitySettingsExtension(settings) { ext ->
+                          ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                          ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                      }
+
+                      eachDevelocitySettingsExtension(settings,
+                          { develocity ->
+                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                              develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                          },
+                          { gradleEnterprise ->
+                              gradleEnterprise.buildScan.publishAlways()
+                              if (isAtLeast(develocityPluginVersion, '2.1')) {
+                                  logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                  if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                      gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                  } else {
+                                      gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                  }
+                              }
+                          }
+                      )
+                  }
+
+                  if (develocityUrl && develocityEnforceUrl) {
+                      logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                  }
+
+                  eachDevelocitySettingsExtension(settings,
+                      { develocity ->
+                          if (develocityUrl && develocityEnforceUrl) {
+                              develocity.server = develocityUrl
+                              develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                          }
+
+                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                          }
+                      },
+                      { gradleEnterprise ->
+                          if (develocityUrl && develocityEnforceUrl) {
+                              gradleEnterprise.server = develocityUrl
+                              gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                          }
+
+                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                              gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                              gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                          }
+                      }
+                  )
+              }
+
+              if (ccudPluginVersion) {
+                  if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                      logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                      settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                  }
+              }
+          }
+      }
+
+      void applyPluginExternally(def pluginManager, String pluginClassName) {
+          def externallyApplied = 'develocity.externally-applied'
+          def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
+          def oldValue = System.getProperty(externallyApplied)
+          def oldValueDeprecated = System.getProperty(externallyAppliedDeprecated)
+          System.setProperty(externallyApplied, 'true')
+          System.setProperty(externallyAppliedDeprecated, 'true')
+          try {
+              pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
+          } finally {
+              if (oldValue == null) {
+                  System.clearProperty(externallyApplied)
+              } else {
+                  System.setProperty(externallyApplied, oldValue)
+              }
+              if (oldValueDeprecated == null) {
+                  System.clearProperty(externallyAppliedDeprecated)
+              } else {
+                  System.setProperty(externallyAppliedDeprecated, oldValueDeprecated)
+              }
+          }
+      }
+
+      /**
+          * Apply the `dvAction` to all 'develocity' extensions.
+          * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
+          * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+          */
+      static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
+          def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+          def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
+
+          def dvExtensions = settings.extensions.extensionsSchema.elements
+              .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
+              .collect { settings[it.name] }
+          if (!dvExtensions.empty) {
+              dvExtensions.each(dvAction)
+          } else {
+              def geExtensions = settings.extensions.extensionsSchema.elements
+                  .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
+                  .collect { settings[it.name] }
+              geExtensions.each(geAction)
+          }
+      }
+
+      static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
+          GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
+      }
+
+      static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
+          !isAtLeast(versionUnderTest, referenceVersion)
+      }


### PR DESCRIPTION
Previously, init-script content was inlined directly into 'develocity-gradle.yml'

To facilitate sharing and ease maintenance, these contents have been extracted into separate files. 
- Raw init-script content in `src/gradle/init-scripts`
- Template for yml file in `src/gradle/develocity-gradle.template.yml'
- Build script to regenerate final yml is `build.sh`
- The `build-verification` workflow verifies that the `develocity-gradle.yml` file in the repo is up-to-date with respect to source inputs
