### PR TITLE
Leverage build-scan-link-capture functionality from reference init-script

### DIFF
--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -136,6 +136,11 @@ spec:
     local initScript="${CI_PROJECT_DIR}/init-script.gradle"
 
     cat > $initScript <<'EOF'
+      /*
+       * Initscript for injection of Develocity into Gradle builds.
+       * Version: v0.4.0
+       */
+      
       import org.gradle.util.GradleVersion
       
       // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
@@ -147,8 +152,9 @@ spec:
               return
           }
       
+          def ENV_VAR_PREFIX = ''
           def getInputParam = { String name ->
-              def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+              def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
               return System.getProperty(name) ?: System.getenv(envVarName)
           }
       
@@ -231,8 +237,9 @@ spec:
           return
       }
       
+      def ENV_VAR_PREFIX = ''
       def getInputParam = { String name ->
-          def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+          def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
           return System.getProperty(name) ?: System.getenv(envVarName)
       }
       
@@ -277,7 +284,7 @@ spec:
           return
       }
       
-      // register buildScanPublished listener and optionally apply the Develocity plugin
+      // Conditionally apply and configure the Develocity plugin
       if (GradleVersion.current() < GradleVersion.version('6.0')) {
           rootProject {
               buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
@@ -292,12 +299,12 @@ spec:
                           logger.lifecycle("Applying $pluginClass via init script")
                           applyPluginExternally(pluginManager, pluginClass)
                           def rootExtension = dvOrGe(
-                                  { develocity },
-                                  { buildScan }
+                              { develocity },
+                              { buildScan }
                           )
                           def buildScanExtension = dvOrGe(
-                                  { rootExtension.buildScan },
-                                  { rootExtension }
+                              { rootExtension.buildScan },
+                              { rootExtension }
                           )
                           if (develocityUrl) {
                               logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -471,10 +478,10 @@ spec:
       }
       
       /**
-          * Apply the `dvAction` to all 'develocity' extensions.
-          * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
-          * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
-          */
+       * Apply the `dvAction` to all 'develocity' extensions.
+       * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
+       * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+       */
       static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
           def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
           def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -38,107 +38,13 @@ spec:
       annotations: $CI_PROJECT_DIR/build-scan-links.json
 
 .injectDevelocityForGradle: |
-  function createGradleReportInit() {
-    local initScript="${CI_PROJECT_DIR}/build-result-capture.init.groovy"
-    export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
-
-    cat > $initScript <<'EOF'
-      import org.gradle.util.GradleVersion
-      import java.util.concurrent.atomic.AtomicBoolean
-      
-      def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
-      def BUILD_SCAN_EXTENSION = "buildScan"
-      def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
-      def DEVELOCITY_EXTENSION = "develocity"
-      def GE_PLUGIN_ID = "com.gradle.enterprise"
-      def GE_EXTENSION = "gradleEnterprise"
-      
-      // Only run against root build. Do not run against included builds.
-      def isTopLevelBuild = gradle.getParent() == null
-      if (isTopLevelBuild) {
-        def version = GradleVersion.current().baseVersion
-      
-        def atLeastGradle3 = version >= GradleVersion.version("3.0")
-        def atLeastGradle6 = version >= GradleVersion.version("6.0")
-        def captureMarker = new AtomicBoolean(false)
-      
-        if (atLeastGradle6) {
-          settingsEvaluated { settings ->
-            settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
-              // Only execute if develocity plugin isn't applied.
-              if (!settings.extensions.findByName(DEVELOCITY_EXTENSION)) {
-                captureUsingBuildScanPublished(settings.extensions[GE_EXTENSION].buildScan, settings.rootProject, captureMarker)
-              }
-            }
-            settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-              captureUsingBuildScanPublished(settings.extensions[DEVELOCITY_EXTENSION].buildScan, settings.rootProject, captureMarker)
-            }
-          }
-        } else if (atLeastGradle3) {
-          projectsEvaluated { gradle ->
-            gradle.rootProject.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-              // Only execute if develocity plugin isn't applied.
-              if (!gradle.rootProject.extensions.findByName(DEVELOCITY_EXTENSION)) {
-                captureUsingBuildScanPublished(gradle.rootProject.extensions[BUILD_SCAN_EXTENSION], gradle.rootProject, captureMarker)
-              }
-            }
-            gradle.rootProject.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-              captureUsingBuildScanPublished(gradle.rootProject.extensions[DEVELOCITY_EXTENSION].buildScan, gradle.rootProject, captureMarker)
-            }
-          }
-        }
-      }
-      
-      def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
-        if (captureMarker.compareAndSet(false, true)) {
-          buildScanExtension.with {
-            buildScanPublished { buildScan ->
-              if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
-                def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
-                def report
-                // This might have been created by a previous Gradle invocation in the same GitLab job
-                // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
-                if (reportFile.exists()) {
-                  report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
-                } else {
-                  report = new Report()
-                }
-                report.addLink("${buildScan.buildScanUri}")
-                def generator = new groovy.json.JsonGenerator.Options()
-                  .excludeFieldsByName('contentHash', 'originalClassName')
-                  .build()
-                reportFile.text = generator.toJson(report)
-              }
-            }
-          }
-        }
-      }
-      
-      class Report {
-        List<Link> build_scans = []
-      
-        void addLink(String url) {
-          build_scans << new Link(url)
-        }
-      }
-      
-      class Link {
-        Map external_link
-      
-        Link(String url) {
-          external_link = [ 'label': url, 'url': url ]
-        }
-      }
-  EOF
-  }
-
   function createGradleInit() {
     local initScript="${CI_PROJECT_DIR}/init-script.gradle"
 
     cat > $initScript <<'EOF'
       /*
        * Initscript for injection of Develocity into Gradle builds.
-       * Version: v0.4.0
+       * Version: v0.5.0
        */
       
       import org.gradle.util.GradleVersion
@@ -152,8 +58,8 @@ spec:
               return
           }
       
-          def ENV_VAR_PREFIX = ''
           def getInputParam = { String name ->
+              def ENV_VAR_PREFIX = ''
               def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
               return System.getProperty(name) ?: System.getenv(envVarName)
           }
@@ -164,9 +70,9 @@ spec:
               return
           }
       
-          // finish early if injection is disabled
-          def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-          if (gradleInjectionEnabled != "true") {
+          // plugin loading is only required for Develocity injection
+          def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+          if (!develocityInjectionEnabled) {
               return
           }
       
@@ -219,28 +125,15 @@ spec:
           }
       }
       
-      def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-      def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-      
-      def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
-      def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-      
-      def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-      def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-      
-      def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-      def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-      def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+      static getInputParam(String name) {
+          def ENV_VAR_PREFIX = ''
+          def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+          return System.getProperty(name) ?: System.getenv(envVarName)
+      }
       
       def isTopLevelBuild = !gradle.parent
       if (!isTopLevelBuild) {
           return
-      }
-      
-      def ENV_VAR_PREFIX = ''
-      def getInputParam = { String name ->
-          def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-          return System.getProperty(name) ?: System.getenv(envVarName)
       }
       
       def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
@@ -250,205 +143,224 @@ spec:
           return
       }
       
-      // finish early if injection is disabled
-      def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-      if (gradleInjectionEnabled != "true") {
-          return
+      def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+      if (develocityInjectionEnabled) {
+          enableDevelocityInjection()
       }
       
-      def develocityUrl = getInputParam('develocity.url')
-      def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-      def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-      def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-      def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
-      def develocityPluginVersion = getInputParam('develocity.plugin.version')
-      def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-      def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-      def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-      def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+      def buildScanCaptureEnabled = this.metaClass.respondsTo(this, 'captureBuildScanLink', String)
+      if (buildScanCaptureEnabled) {
+          enableBuildScanLinkCapture()
+      }
       
-      def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-      def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-      def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+      void enableDevelocityInjection() {
+          def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+          def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
       
-      def dvOrGe = { def dvValue, def geValue ->
-          if (shouldApplyDevelocityPlugin) {
-              return dvValue instanceof Closure<?> ? dvValue() : dvValue
+          def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+          def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+      
+          def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+          def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+      
+          def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+          def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+          def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+      
+          def develocityUrl = getInputParam('develocity.url')
+          def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+          def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+          def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+          def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+          def develocityPluginVersion = getInputParam('develocity.plugin.version')
+          def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+          def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+          def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+          def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+      
+          def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+          def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+          def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+      
+          def dvOrGe = { def dvValue, def geValue ->
+              if (shouldApplyDevelocityPlugin) {
+                  return dvValue instanceof Closure<?> ? dvValue() : dvValue
+              }
+              return geValue instanceof Closure<?> ? geValue() : geValue
           }
-          return geValue instanceof Closure<?> ? geValue() : geValue
-      }
       
-      // finish early if configuration parameters passed in via system properties are not valid/supported
-      if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-          logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
-          return
-      }
+          // finish early if configuration parameters passed in via system properties are not valid/supported
+          if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+              logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+              return
+          }
       
-      // Conditionally apply and configure the Develocity plugin
-      if (GradleVersion.current() < GradleVersion.version('6.0')) {
-          rootProject {
-              buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
-                  def resolutionResult = incoming.resolutionResult
+          // Conditionally apply and configure the Develocity plugin
+          if (GradleVersion.current() < GradleVersion.version('6.0')) {
+              rootProject {
+                  buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+                      def resolutionResult = incoming.resolutionResult
       
-                  if (develocityPluginVersion) {
-                      def scanPluginComponent = resolutionResult.allComponents.find {
-                          it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
-                      }
-                      if (!scanPluginComponent) {
-                          def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                          logger.lifecycle("Applying $pluginClass via init script")
-                          applyPluginExternally(pluginManager, pluginClass)
-                          def rootExtension = dvOrGe(
-                              { develocity },
-                              { buildScan }
-                          )
-                          def buildScanExtension = dvOrGe(
-                              { rootExtension.buildScan },
-                              { rootExtension }
-                          )
-                          if (develocityUrl) {
-                              logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              rootExtension.server = develocityUrl
-                              rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                      if (develocityPluginVersion) {
+                          def scanPluginComponent = resolutionResult.allComponents.find {
+                              it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
                           }
-                          if (!shouldApplyDevelocityPlugin) {
-                              // Develocity plugin publishes scans by default
-                              buildScanExtension.publishAlways()
-                          }
-                          // uploadInBackground not available for build-scan-plugin 1.16
-                          if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
-                          buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                          if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              if (isAtLeast(develocityPluginVersion, '3.17')) {
-                                  buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                              } else if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                  buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
-                              } else {
-                                  buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                          if (!scanPluginComponent) {
+                              def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                              logger.lifecycle("Applying $pluginClass via init script")
+                              applyPluginExternally(pluginManager, pluginClass)
+                              def rootExtension = dvOrGe(
+                                  { develocity },
+                                  { buildScan }
+                              )
+                              def buildScanExtension = dvOrGe(
+                                  { rootExtension.buildScan },
+                                  { rootExtension }
+                              )
+                              if (develocityUrl) {
+                                  logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                  rootExtension.server = develocityUrl
+                                  rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                              }
+                              if (!shouldApplyDevelocityPlugin) {
+                                  // Develocity plugin publishes scans by default
+                                  buildScanExtension.publishAlways()
+                              }
+                              // uploadInBackground not available for build-scan-plugin 1.16
+                              if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                              buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                              if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                                  logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                  if (isAtLeast(develocityPluginVersion, '3.17')) {
+                                      buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                                  } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                      buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                  } else {
+                                      buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                  }
                               }
                           }
+      
+                          if (develocityUrl && develocityEnforceUrl) {
+                              logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                          }
+      
+                          pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                              // Only execute if develocity plugin isn't applied.
+                              if (gradle.rootProject.extensions.findByName("develocity")) return
+                              afterEvaluate {
+                                  if (develocityUrl && develocityEnforceUrl) {
+                                      buildScan.server = develocityUrl
+                                      buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                                  }
+                              }
+      
+                              if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                                  buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                                  buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                              }
+                          }
+      
+                          pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                              afterEvaluate {
+                                  if (develocityUrl && develocityEnforceUrl) {
+                                      develocity.server = develocityUrl
+                                      develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                                  }
+                              }
+      
+                              if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                                  develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                                  develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                              }
+                          }
+                      }
+      
+                      if (ccudPluginVersion && atLeastGradle4) {
+                          def ccudPluginComponent = resolutionResult.allComponents.find {
+                              it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                          }
+                          if (!ccudPluginComponent) {
+                              logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                              pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                          }
+                      }
+                  }
+              }
+          } else {
+              gradle.settingsEvaluated { settings ->
+                  if (develocityPluginVersion) {
+                      if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                          def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                          logger.lifecycle("Applying $pluginClass via init script")
+                          applyPluginExternally(settings.pluginManager, pluginClass)
+                          if (develocityUrl) {
+                              logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                              eachDevelocitySettingsExtension(settings) { ext ->
+                                  ext.server = develocityUrl
+                                  ext.allowUntrustedServer = develocityAllowUntrustedServer
+                              }
+                          }
+      
+                          eachDevelocitySettingsExtension(settings) { ext ->
+                              ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                              ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                          }
+      
+                          eachDevelocitySettingsExtension(settings,
+                              { develocity ->
+                                  logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                  develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                              },
+                              { gradleEnterprise ->
+                                  gradleEnterprise.buildScan.publishAlways()
+                                  if (isAtLeast(develocityPluginVersion, '2.1')) {
+                                      logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                      if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                          gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                      } else {
+                                          gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                      }
+                                  }
+                              }
+                          )
                       }
       
                       if (develocityUrl && develocityEnforceUrl) {
                           logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                       }
       
-                      pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                          // Only execute if develocity plugin isn't applied.
-                          if (gradle.rootProject.extensions.findByName("develocity")) return
-                          afterEvaluate {
-                              if (develocityUrl && develocityEnforceUrl) {
-                                  buildScan.server = develocityUrl
-                                  buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                              }
-                          }
-      
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                              buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                          }
-                      }
-      
-                      pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                          afterEvaluate {
+                      eachDevelocitySettingsExtension(settings,
+                          { develocity ->
                               if (develocityUrl && develocityEnforceUrl) {
                                   develocity.server = develocityUrl
                                   develocity.allowUntrustedServer = develocityAllowUntrustedServer
                               }
-                          }
       
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                          }
-                      }
-                  }
-      
-                  if (ccudPluginVersion && atLeastGradle4) {
-                      def ccudPluginComponent = resolutionResult.allComponents.find {
-                          it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
-                      }
-                      if (!ccudPluginComponent) {
-                          logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                          pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                      }
-                  }
-              }
-          }
-      } else {
-          gradle.settingsEvaluated { settings ->
-              if (develocityPluginVersion) {
-                  if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                      def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                      logger.lifecycle("Applying $pluginClass via init script")
-                      applyPluginExternally(settings.pluginManager, pluginClass)
-                      if (develocityUrl) {
-                          logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                          eachDevelocitySettingsExtension(settings) { ext ->
-                              ext.server = develocityUrl
-                              ext.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
-                      }
-      
-                      eachDevelocitySettingsExtension(settings) { ext ->
-                          ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                          ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                      }
-      
-                      eachDevelocitySettingsExtension(settings,
-                          { develocity ->
-                              logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                              develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                              if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                                  develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                                  develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                              }
                           },
                           { gradleEnterprise ->
-                              gradleEnterprise.buildScan.publishAlways()
-                              if (isAtLeast(develocityPluginVersion, '2.1')) {
-                                  logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                                  if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                      gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                                  } else {
-                                      gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                                  }
+                              if (develocityUrl && develocityEnforceUrl) {
+                                  gradleEnterprise.server = develocityUrl
+                                  gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                              }
+      
+                              if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                                  gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                                  gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                               }
                           }
                       )
                   }
       
-                  if (develocityUrl && develocityEnforceUrl) {
-                      logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                  }
-      
-                  eachDevelocitySettingsExtension(settings,
-                      { develocity ->
-                          if (develocityUrl && develocityEnforceUrl) {
-                              develocity.server = develocityUrl
-                              develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
-      
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                              develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                          }
-                      },
-                      { gradleEnterprise ->
-                          if (develocityUrl && develocityEnforceUrl) {
-                              gradleEnterprise.server = develocityUrl
-                              gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                          }
-      
-                          if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                              gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                              gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                          }
+                  if (ccudPluginVersion) {
+                      if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                          logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                          settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                       }
-                  )
-              }
-      
-              if (ccudPluginVersion) {
-                  if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                      logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                      settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                   }
               }
           }
@@ -506,12 +418,81 @@ spec:
       static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
           !isAtLeast(versionUnderTest, referenceVersion)
       }
-
-      apply from: "${System.getenv('CI_PROJECT_DIR')}/build-result-capture.init.groovy"
-
+      
+      void enableBuildScanLinkCapture() {
+          def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+          def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+      
+          // Conditionally apply and configure the Develocity plugin
+          if (GradleVersion.current() < GradleVersion.version('6.0')) {
+              rootProject {
+                  pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                      // Only execute if develocity plugin isn't applied.
+                      if (gradle.rootProject.extensions.findByName("develocity")) return
+                      buildScanPublishedAction(buildScan)
+                  }
+      
+                  pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                      buildScanPublishedAction(develocity.buildScan)
+                  }
+              }
+          } else {
+              gradle.settingsEvaluated { settings ->
+                  eachDevelocitySettingsExtension(settings) { ext ->
+                      buildScanPublishedAction(ext.buildScan)
+                  }
+              }
+          }
+      }
+      
+      // Action will only be called if a `captureBuildScanUrl(String)` method is present in this file.
+      // Add a `void captureBuildScanLink(String) {}` method to respond to buildScanPublished events
+      void buildScanPublishedAction(def buildScanExtension) {
+          if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'buildScanPublished', Action)) {
+              buildScanExtension.buildScanPublished { scan ->
+                  captureBuildScanLink(scan.buildScanUri.toString())
+              }
+          }
+      }
+      
+      def captureBuildScanLink(buildScanLink) {
+        if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
+          def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
+          def report
+          // This might have been created by a previous Gradle invocation in the same GitLab job
+          // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
+          if (reportFile.exists()) {
+            report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
+          } else {
+            report = new Report()
+          }
+          report.addLink(buildScanLink)
+          def generator = new groovy.json.JsonGenerator.Options()
+            .excludeFieldsByName('contentHash', 'originalClassName')
+            .build()
+          reportFile.text = generator.toJson(report)
+        }
+      }
+      
+      class Report {
+        List<Link> build_scans = []
+      
+        void addLink(String url) {
+          build_scans << new Link(url)
+        }
+      }
+      
+      class Link {
+        Map external_link
+      
+        Link(String url) {
+          external_link = [ 'label': url, 'url': url ]
+        }
+      }
   EOF
 
     export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
+    export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
   }
 
   function createShortLivedToken() {
@@ -640,7 +621,6 @@ spec:
     export "GRADLE_PLUGIN_REPOSITORY_PASSWORD=$[[ inputs.gradlePluginRepositoryPassword ]]"
   }
 
-  createGradleReportInit
   createGradleInit
   createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
   injectDevelocityForGradle

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -38,26 +38,16 @@ spec:
       annotations: $CI_PROJECT_DIR/build-scan-links.json
 
 .injectDevelocityForGradle: |
-  function createGradleReportInit() {
-    local initScript="${CI_PROJECT_DIR}/build-result-capture.init.groovy"
-    export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
-
-    cat > $initScript <<'EOF'
-<<BUILD_RESULT_CAPTURE_INIT_GROOVY>>
-  EOF
-  }
-
   function createGradleInit() {
     local initScript="${CI_PROJECT_DIR}/init-script.gradle"
 
     cat > $initScript <<'EOF'
 <<DEVELOCITY_INJECTION_INIT_GRADLE>>
-
-      apply from: "${System.getenv('CI_PROJECT_DIR')}/build-result-capture.init.groovy"
-
+<<BUILD_RESULT_CAPTURE_INIT_GROOVY>>
   EOF
 
     export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
+    export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
   }
 
   function createShortLivedToken() {
@@ -186,7 +176,6 @@ spec:
     export "GRADLE_PLUGIN_REPOSITORY_PASSWORD=$[[ inputs.gradlePluginRepositoryPassword ]]"
   }
 
-  createGradleReportInit
   createGradleInit
   createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
   injectDevelocityForGradle

--- a/src/gradle/init-scripts/build-result-capture.init.gradle
+++ b/src/gradle/init-scripts/build-result-capture.init.gradle
@@ -1,71 +1,20 @@
-import org.gradle.util.GradleVersion
-import java.util.concurrent.atomic.AtomicBoolean
 
-def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
-def BUILD_SCAN_EXTENSION = "buildScan"
-def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
-def DEVELOCITY_EXTENSION = "develocity"
-def GE_PLUGIN_ID = "com.gradle.enterprise"
-def GE_EXTENSION = "gradleEnterprise"
-
-// Only run against root build. Do not run against included builds.
-def isTopLevelBuild = gradle.getParent() == null
-if (isTopLevelBuild) {
-  def version = GradleVersion.current().baseVersion
-
-  def atLeastGradle3 = version >= GradleVersion.version("3.0")
-  def atLeastGradle6 = version >= GradleVersion.version("6.0")
-  def captureMarker = new AtomicBoolean(false)
-
-  if (atLeastGradle6) {
-    settingsEvaluated { settings ->
-      settings.pluginManager.withPlugin(GE_PLUGIN_ID) {
-        // Only execute if develocity plugin isn't applied.
-        if (!settings.extensions.findByName(DEVELOCITY_EXTENSION)) {
-          captureUsingBuildScanPublished(settings.extensions[GE_EXTENSION].buildScan, settings.rootProject, captureMarker)
-        }
-      }
-      settings.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-        captureUsingBuildScanPublished(settings.extensions[DEVELOCITY_EXTENSION].buildScan, settings.rootProject, captureMarker)
-      }
+def captureBuildScanLink(String buildScanLink) {
+  if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
+    def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
+    def report
+    // This might have been created by a previous Gradle invocation in the same GitLab job
+    // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
+    if (reportFile.exists()) {
+      report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
+    } else {
+      report = new Report()
     }
-  } else if (atLeastGradle3) {
-    projectsEvaluated { gradle ->
-      gradle.rootProject.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-        // Only execute if develocity plugin isn't applied.
-        if (!gradle.rootProject.extensions.findByName(DEVELOCITY_EXTENSION)) {
-          captureUsingBuildScanPublished(gradle.rootProject.extensions[BUILD_SCAN_EXTENSION], gradle.rootProject, captureMarker)
-        }
-      }
-      gradle.rootProject.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-        captureUsingBuildScanPublished(gradle.rootProject.extensions[DEVELOCITY_EXTENSION].buildScan, gradle.rootProject, captureMarker)
-      }
-    }
-  }
-}
-
-def captureUsingBuildScanPublished(buildScanExtension, rootProject, AtomicBoolean captureMarker) {
-  if (captureMarker.compareAndSet(false, true)) {
-    buildScanExtension.with {
-      buildScanPublished { buildScan ->
-        if (System.getenv("BUILD_SCAN_REPORT_PATH")) {
-          def reportFile = new File(System.getenv("BUILD_SCAN_REPORT_PATH"))
-          def report
-          // This might have been created by a previous Gradle invocation in the same GitLab job
-          // Note that we do not handle parallel Gradle scripts invocation, which should be a very edge case in context of a GitLab job
-          if (reportFile.exists()) {
-            report = new groovy.json.JsonSlurper().parseText(reportFile.text) as Report
-          } else {
-            report = new Report()
-          }
-          report.addLink("${buildScan.buildScanUri}")
-          def generator = new groovy.json.JsonGenerator.Options()
-            .excludeFieldsByName('contentHash', 'originalClassName')
-            .build()
-          reportFile.text = generator.toJson(report)
-        }
-      }
-    }
+    report.addLink(buildScanLink)
+    def generator = new groovy.json.JsonGenerator.Options()
+      .excludeFieldsByName('contentHash', 'originalClassName')
+      .build()
+    reportFile.text = generator.toJson(report)
   }
 }
 

--- a/src/gradle/init-scripts/develocity-injection.init.gradle
+++ b/src/gradle/init-scripts/develocity-injection.init.gradle
@@ -1,3 +1,8 @@
+/*
+ * Initscript for injection of Develocity into Gradle builds.
+ * Version: v0.4.0
+ */
+
 import org.gradle.util.GradleVersion
 
 // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
@@ -9,8 +14,9 @@ initscript {
         return
     }
 
+    def ENV_VAR_PREFIX = ''
     def getInputParam = { String name ->
-        def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+        def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
 
@@ -93,8 +99,9 @@ if (!isTopLevelBuild) {
     return
 }
 
+def ENV_VAR_PREFIX = ''
 def getInputParam = { String name ->
-    def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
@@ -139,7 +146,7 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
     return
 }
 
-// register buildScanPublished listener and optionally apply the Develocity plugin
+// Conditionally apply and configure the Develocity plugin
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
         buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
@@ -154,12 +161,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $pluginClass via init script")
                     applyPluginExternally(pluginManager, pluginClass)
                     def rootExtension = dvOrGe(
-                            { develocity },
-                            { buildScan }
+                        { develocity },
+                        { buildScan }
                     )
                     def buildScanExtension = dvOrGe(
-                            { rootExtension.buildScan },
-                            { rootExtension }
+                        { rootExtension.buildScan },
+                        { rootExtension }
                     )
                     if (develocityUrl) {
                         logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -333,10 +340,10 @@ void applyPluginExternally(def pluginManager, String pluginClassName) {
 }
 
 /**
-    * Apply the `dvAction` to all 'develocity' extensions.
-    * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
-    * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
-    */
+ * Apply the `dvAction` to all 'develocity' extensions.
+ * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
+ * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+ */
 static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
     def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
     def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'

--- a/src/gradle/init-scripts/develocity-injection.init.gradle
+++ b/src/gradle/init-scripts/develocity-injection.init.gradle
@@ -1,6 +1,6 @@
 /*
  * Initscript for injection of Develocity into Gradle builds.
- * Version: v0.4.0
+ * Version: v0.5.0-unpublished
  */
 
 import org.gradle.util.GradleVersion
@@ -14,8 +14,8 @@ initscript {
         return
     }
 
-    def ENV_VAR_PREFIX = ''
     def getInputParam = { String name ->
+        def ENV_VAR_PREFIX = ''
         def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
@@ -26,9 +26,9 @@ initscript {
         return
     }
 
-    // finish early if injection is disabled
-    def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-    if (gradleInjectionEnabled != "true") {
+    // plugin loading is only required for Develocity injection
+    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+    if (!develocityInjectionEnabled) {
         return
     }
 
@@ -81,28 +81,15 @@ initscript {
     }
 }
 
-def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-
-def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
-def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-
-def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-
-def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+static getInputParam(String name) {
+    def ENV_VAR_PREFIX = ''
+    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+    return System.getProperty(name) ?: System.getenv(envVarName)
+}
 
 def isTopLevelBuild = !gradle.parent
 if (!isTopLevelBuild) {
     return
-}
-
-def ENV_VAR_PREFIX = ''
-def getInputParam = { String name ->
-    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
 def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
@@ -112,205 +99,224 @@ if (requestedInitScriptName != initScriptName) {
     return
 }
 
-// finish early if injection is disabled
-def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-if (gradleInjectionEnabled != "true") {
-    return
+def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+if (develocityInjectionEnabled) {
+    enableDevelocityInjection()
 }
 
-def develocityUrl = getInputParam('develocity.url')
-def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
-def develocityPluginVersion = getInputParam('develocity.plugin.version')
-def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+def buildScanCaptureEnabled = this.metaClass.respondsTo(this, 'captureBuildScanLink', String)
+if (buildScanCaptureEnabled) {
+    enableBuildScanLinkCapture()
+}
 
-def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+void enableDevelocityInjection() {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-def dvOrGe = { def dvValue, def geValue ->
-    if (shouldApplyDevelocityPlugin) {
-        return dvValue instanceof Closure<?> ? dvValue() : dvValue
+    def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+    def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+    def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+
+    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+    def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+    def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
+    def develocityUrl = getInputParam('develocity.url')
+    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+    def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
+    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+    def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+    def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+    def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+    def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+
+    def dvOrGe = { def dvValue, def geValue ->
+        if (shouldApplyDevelocityPlugin) {
+            return dvValue instanceof Closure<?> ? dvValue() : dvValue
+        }
+        return geValue instanceof Closure<?> ? geValue() : geValue
     }
-    return geValue instanceof Closure<?> ? geValue() : geValue
-}
 
-// finish early if configuration parameters passed in via system properties are not valid/supported
-if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-    logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
-    return
-}
+    // finish early if configuration parameters passed in via system properties are not valid/supported
+    if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+        logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+        return
+    }
 
-// Conditionally apply and configure the Develocity plugin
-if (GradleVersion.current() < GradleVersion.version('6.0')) {
-    rootProject {
-        buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
-            def resolutionResult = incoming.resolutionResult
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+                def resolutionResult = incoming.resolutionResult
 
-            if (develocityPluginVersion) {
-                def scanPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
-                }
-                if (!scanPluginComponent) {
-                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                    logger.lifecycle("Applying $pluginClass via init script")
-                    applyPluginExternally(pluginManager, pluginClass)
-                    def rootExtension = dvOrGe(
-                        { develocity },
-                        { buildScan }
-                    )
-                    def buildScanExtension = dvOrGe(
-                        { rootExtension.buildScan },
-                        { rootExtension }
-                    )
-                    if (develocityUrl) {
-                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        rootExtension.server = develocityUrl
-                        rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                if (develocityPluginVersion) {
+                    def scanPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
                     }
-                    if (!shouldApplyDevelocityPlugin) {
-                        // Develocity plugin publishes scans by default
-                        buildScanExtension.publishAlways()
-                    }
-                    // uploadInBackground not available for build-scan-plugin 1.16
-                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
-                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                    if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        if (isAtLeast(develocityPluginVersion, '3.17')) {
-                            buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                        } else if (isAtLeast(develocityPluginVersion, '3.7')) {
-                            buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
-                        } else {
-                            buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                    if (!scanPluginComponent) {
+                        def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                        logger.lifecycle("Applying $pluginClass via init script")
+                        applyPluginExternally(pluginManager, pluginClass)
+                        def rootExtension = dvOrGe(
+                            { develocity },
+                            { buildScan }
+                        )
+                        def buildScanExtension = dvOrGe(
+                            { rootExtension.buildScan },
+                            { rootExtension }
+                        )
+                        if (develocityUrl) {
+                            logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            rootExtension.server = develocityUrl
+                            rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                        if (!shouldApplyDevelocityPlugin) {
+                            // Develocity plugin publishes scans by default
+                            buildScanExtension.publishAlways()
+                        }
+                        // uploadInBackground not available for build-scan-plugin 1.16
+                        if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                        buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                        if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            if (isAtLeast(develocityPluginVersion, '3.17')) {
+                                buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                            } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                            } else {
+                                buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                            }
                         }
                     }
+
+                    if (develocityUrl && develocityEnforceUrl) {
+                        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                    }
+
+                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                        // Only execute if develocity plugin isn't applied.
+                        if (gradle.rootProject.extensions.findByName("develocity")) return
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                buildScan.server = develocityUrl
+                                buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+
+                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                develocity.server = develocityUrl
+                                develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+                }
+
+                if (ccudPluginVersion && atLeastGradle4) {
+                    def ccudPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                    }
+                    if (!ccudPluginComponent) {
+                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                        pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                    }
+                }
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            if (develocityPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                    logger.lifecycle("Applying $pluginClass via init script")
+                    applyPluginExternally(settings.pluginManager, pluginClass)
+                    if (develocityUrl) {
+                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        eachDevelocitySettingsExtension(settings) { ext ->
+                            ext.server = develocityUrl
+                            ext.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
+
+                    eachDevelocitySettingsExtension(settings) { ext ->
+                        ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                        ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                    }
+
+                    eachDevelocitySettingsExtension(settings,
+                        { develocity ->
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                        },
+                        { gradleEnterprise ->
+                            gradleEnterprise.buildScan.publishAlways()
+                            if (isAtLeast(develocityPluginVersion, '2.1')) {
+                                logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                    gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                } else {
+                                    gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                }
+                            }
+                        }
+                    )
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
                     logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                 }
 
-                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                    // Only execute if develocity plugin isn't applied.
-                    if (gradle.rootProject.extensions.findByName("develocity")) return
-                    afterEvaluate {
-                        if (develocityUrl && develocityEnforceUrl) {
-                            buildScan.server = develocityUrl
-                            buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                        buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                    }
-                }
-
-                pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                    afterEvaluate {
+                eachDevelocitySettingsExtension(settings,
+                    { develocity ->
                         if (develocityUrl && develocityEnforceUrl) {
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
-                    }
 
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                    }
-                }
-            }
-
-            if (ccudPluginVersion && atLeastGradle4) {
-                def ccudPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
-                }
-                if (!ccudPluginComponent) {
-                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                    pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                }
-            }
-        }
-    }
-} else {
-    gradle.settingsEvaluated { settings ->
-        if (develocityPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                logger.lifecycle("Applying $pluginClass via init script")
-                applyPluginExternally(settings.pluginManager, pluginClass)
-                if (develocityUrl) {
-                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                    eachDevelocitySettingsExtension(settings) { ext ->
-                        ext.server = develocityUrl
-                        ext.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-                }
-
-                eachDevelocitySettingsExtension(settings) { ext ->
-                    ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                }
-
-                eachDevelocitySettingsExtension(settings,
-                    { develocity ->
-                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
                     },
                     { gradleEnterprise ->
-                        gradleEnterprise.buildScan.publishAlways()
-                        if (isAtLeast(develocityPluginVersion, '2.1')) {
-                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                            if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                            } else {
-                                gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                            }
+                        if (develocityUrl && develocityEnforceUrl) {
+                            gradleEnterprise.server = develocityUrl
+                            gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                         }
                     }
                 )
             }
 
-            if (develocityUrl && develocityEnforceUrl) {
-                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-            }
-
-            eachDevelocitySettingsExtension(settings,
-                { develocity ->
-                    if (develocityUrl && develocityEnforceUrl) {
-                        develocity.server = develocityUrl
-                        develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                    }
-                },
-                { gradleEnterprise ->
-                    if (develocityUrl && develocityEnforceUrl) {
-                        gradleEnterprise.server = develocityUrl
-                        gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                        gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                    }
+            if (ccudPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                    settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                 }
-            )
-        }
-
-        if (ccudPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
             }
         }
     }
@@ -367,4 +373,40 @@ static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     !isAtLeast(versionUnderTest, referenceVersion)
+}
+
+void enableBuildScanLinkCapture() {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                // Only execute if develocity plugin isn't applied.
+                if (gradle.rootProject.extensions.findByName("develocity")) return
+                buildScanPublishedAction(buildScan)
+            }
+
+            pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                buildScanPublishedAction(develocity.buildScan)
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            eachDevelocitySettingsExtension(settings) { ext ->
+                buildScanPublishedAction(ext.buildScan)
+            }
+        }
+    }
+}
+
+// Action will only be called if a `captureBuildScanLink` method is present in this file.
+// Add `void captureBuildScanLink(String) {}` to respond to buildScanPublished events
+void buildScanPublishedAction(def buildScanExtension) {
+    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'buildScanPublished', Action)) {
+        buildScanExtension.buildScanPublished { scan ->
+            captureBuildScanLink(scan.buildScanUri.toString())
+        }
+    }
 }


### PR DESCRIPTION
Pre-emptive change to leverage the upcoming changes in `develocity-inject.init.gradle@v0.5.0`.
Only a52f116d84807ce1bc107e3d13931f4e963c530f will be required once the reference script is updated.