### PR TITLE
 Add init.d setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,46 +69,46 @@ Using GitLab templating, that can be factored and applied to multiple jobs:
 
 ```yml
 .gradle-inject-job:
-    before_script:
-        - !reference [ .injectDevelocityForGradle ]
-    artifacts:
-        !reference [ .build_scan_links_report, artifacts ]
+  before_script:
+    - !reference [ .injectDevelocityForGradle ]
+  artifacts:
+    !reference [ .build_scan_links_report, artifacts ]
 
 build-gradle-job:
-    stage: build
-    extends: .gradle-inject-job
-    script:
-        - ./gradlew build -I $DEVELOCITY_INIT_SCRIPT_PATH
+  stage: build
+  extends: .gradle-inject-job
+  script:
+    - ./gradlew build -I $DEVELOCITY_INIT_SCRIPT_PATH
 
 test-gradle-job:
-    stage: build
-    extends: .gradle-inject-job
-    script:
-        - ./gradlew test -I $DEVELOCITY_INIT_SCRIPT_PATH
+  stage: build
+  extends: .gradle-inject-job
+  script:
+    - ./gradlew test -I $DEVELOCITY_INIT_SCRIPT_PATH
 ```
 
 Optionally, if you'd like to apply the script to all builds, you may add it to the [`init.d` directory](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home). With this approach, passing the script as `-I` to each build is no longer necessary.
 
 ```yml
 .gradle-inject-job:
-    before_script:
-        - !reference [ .injectDevelocityForGradle ]
-        - gradle_init_d="${GRADLE_USER_HOME:-~/.gradle}/init.d"
-        - mkdir -p "$gradle_init_d" && cp "$DEVELOCITY_INIT_SCRIPT_PATH" "$gradle_init_d"
-    artifacts:
-        !reference [ .build_scan_links_report, artifacts ]
+  before_script:
+    - !reference [ .injectDevelocityForGradle ]
+    - gradle_init_d="${GRADLE_USER_HOME:-~/.gradle}/init.d"
+    - mkdir -p "$gradle_init_d" && cp "$DEVELOCITY_INIT_SCRIPT_PATH" "$gradle_init_d"
+  artifacts:
+    !reference [ .build_scan_links_report, artifacts ]
 
 build-gradle-job:
-    stage: build
-    extends: .gradle-inject-job
-    script:
-        - ./gradlew build
+  stage: build
+  extends: .gradle-inject-job
+  script:
+    - ./gradlew build
 
 test-gradle-job:
-    stage: build
-    extends: .gradle-inject-job
-    script:
-        - ./gradlew test
+  stage: build
+  extends: .gradle-inject-job
+  script:
+    - ./gradlew test
 ```
 
 ### Maven Auto-instrumentation

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Optionally, if you'd like to apply the script to all builds, you may add it to t
 .gradle-inject-job:
     before_script:
         - !reference [ .injectDevelocityForGradle ]
-        - mv "$DEVELOCITY_INIT_SCRIPT_PATH" "${GRADLE_USER_HOME:-~/.gradle}"
+        - gradle_init_d="${GRADLE_USER_HOME:-~/.gradle}/init.d"
+        - mkdir -p "$gradle_init_d" && cp "$DEVELOCITY_INIT_SCRIPT_PATH" "$gradle_init_d"
     artifacts:
         !reference [ .build_scan_links_report, artifacts ]
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ test-gradle-job:
         - ./gradlew test -I $DEVELOCITY_INIT_SCRIPT_PATH
 ```
 
+Optionally, if you'd like to apply the script to all builds, you may add it to the [`init.d` directory](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home). With this approach, passing the script as `-I` to each build is no longer necessary.
+
+```yml
+.gradle-inject-job:
+    before_script:
+        - !reference [ .injectDevelocityForGradle ]
+        - mv "$DEVELOCITY_INIT_SCRIPT_PATH" "${GRADLE_USER_HOME:-~/.gradle}"
+    artifacts:
+        !reference [ .build_scan_links_report, artifacts ]
+
+build-gradle-job:
+    stage: build
+    extends: .gradle-inject-job
+    script:
+        - ./gradlew build
+
+test-gradle-job:
+    stage: build
+    extends: .gradle-inject-job
+    script:
+        - ./gradlew test
+```
+
 ### Maven Auto-instrumentation
 Include the remote template and optionally pass inputs.
 To enable Build Scan publishing for Maven builds, the configuration would look something like presented below (using https://develocity.mycompany.com as an example of Develocity server URL.


### PR DESCRIPTION
Suggest the possibility of applying injecting the Develocity init script for all builds by moving it to `init.d`.

Manually tested on a GitLab repository:

- [`.gitlab-ci.yml` file containing the snippet][1] (slightly different as it used `mv` instead of `cp`)
- [Job proving script was applied][2]

[1]: https://gitlab.com/gabrielfeo/android-cache-fix-gradle-plugin-clone/-/blob/53451489b24b13483f81125325c9b40f517ca2d4/.gitlab-ci.yml
[2]: https://gitlab.com/gabrielfeo/android-cache-fix-gradle-plugin-clone/-/jobs/8998432845#L50