### PR TITLE
Bump references to Common Custom User Data Gradle plugin from 2.0.2 to 2.1

### DIFF
--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -14,7 +14,7 @@ spec:
       default: '3.19'
     # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
     ccudPluginVersion:
-      default: '2.0.2'
+      default: '2.1'
     # Develocity Gradle plugin repository URL, defaults in the init script to https://plugins.gradle.org/m2
     gradlePluginRepositoryUrl:
       default: ''

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -14,7 +14,7 @@ spec:
       default: '3.19'
     # Common Custom User Data Gradle Plugin version (see https://github.com/gradle/common-custom-user-data-gradle-plugin/)
     ccudPluginVersion:
-      default: '2.0.2'
+      default: '2.1'
     # Develocity Gradle plugin repository URL, defaults in the init script to https://plugins.gradle.org/m2
     gradlePluginRepositoryUrl:
       default: ''


### PR DESCRIPTION
The version upgrade workflow was failing to create the PR due to the team name change, but the branch was still created. Manually opening the PR and we are fixing the version upgrade workflow.