### PR TITLE
Ignore SSL errors for short lived token request if allowUntrusted

### DIFF
--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -654,15 +654,16 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
-    
+
     local curlOpts="-s -w \n%{http_code} -X POST"
-    if [ "${allowUntrusted}" == "true" ]; then
-      curlOpts="${curlOpts} -k"
+    if [ "${allowUntrusted}" == "true" ];
+    then
+      curlOpts="-k ${curlOpts}"
     fi
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -655,7 +655,7 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts=(-s -w \n%{http_code} -X POST)
+    local curlOpts=(-s -w "\n%{http_code}" -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
     curlOpts+=(-k)

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -46,47 +46,47 @@ spec:
        * Initscript for injection of Develocity into Gradle builds.
        * Version: 1.2
        */
-      
+
       import org.gradle.util.GradleVersion
-      
+
       initscript {
           // NOTE: there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
           def isTopLevelBuild = !gradle.parent
           if (!isTopLevelBuild) {
               return
           }
-      
+
           def getInputParam = { Gradle gradle, String name ->
               def ENV_VAR_PREFIX = ''
               def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
               return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
           }
-      
+
           def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
           def initScriptName = buildscript.sourceFile.name
           if (requestedInitScriptName != initScriptName) {
               return
           }
-      
+
           // Plugin loading is only required for Develocity injection. Abort early if not enabled.
           def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
           if (!develocityInjectionEnabled) {
               return
           }
-      
+
           def pluginRepositoryUrl = getInputParam(gradle, 'gradle.plugin-repository.url')
           def pluginRepositoryUsername = getInputParam(gradle, 'gradle.plugin-repository.username')
           def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
           def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
           def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
-      
+
           def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
           def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-      
+
           if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
               pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
               logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
-      
+
               repositories {
                   maven {
                       url = pluginRepositoryUrl
@@ -103,7 +103,7 @@ spec:
                   }
               }
           }
-      
+
           dependencies {
               if (develocityPluginVersion) {
                   if (atLeastGradle5) {
@@ -116,56 +116,56 @@ spec:
                       classpath "com.gradle:build-scan-plugin:1.16"
                   }
               }
-      
+
               if (ccudPluginVersion && atLeastGradle4) {
                   classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
               }
           }
       }
-      
+
       static getInputParam(Gradle gradle, String name) {
           def ENV_VAR_PREFIX = ''
           def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
           return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
       }
-      
+
       def isTopLevelBuild = !gradle.parent
       if (!isTopLevelBuild) {
           return
       }
-      
+
       def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
       def initScriptName = buildscript.sourceFile.name
       if (requestedInitScriptName != initScriptName) {
           logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
           return
       }
-      
+
       def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
       if (develocityInjectionEnabled) {
           enableDevelocityInjection()
       }
-      
+
       // To enable build-scan capture, a `captureBuildScanLink(String)` method must be added to `BuildScanCollector`.
       def buildScanCollector = new BuildScanCollector()
       def buildScanCaptureEnabled = buildScanCollector.metaClass.respondsTo(buildScanCollector, 'captureBuildScanLink', String)
       if (buildScanCaptureEnabled) {
           enableBuildScanLinkCapture(buildScanCollector)
       }
-      
+
       void enableDevelocityInjection() {
           def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-      
+
           def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
           def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-      
+
           def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
           def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-      
+
           def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
           def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
           def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
-      
+
           def develocityUrl = getInputParam(gradle, 'develocity.url')
           def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity.allow-untrusted-server'))
           def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity.enforce-url'))
@@ -176,44 +176,44 @@ spec:
           def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity.terms-of-use.url')
           def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity.terms-of-use.agree')
           def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity.auto-injection.custom-value')
-      
+
           def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
           def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
           def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
-      
+
           def dvOrGe = { def dvValue, def geValue ->
               if (shouldApplyDevelocityPlugin) {
                   return dvValue instanceof Closure<?> ? dvValue() : dvValue
               }
               return geValue instanceof Closure<?> ? geValue() : geValue
           }
-      
+
           def printEnforcingDevelocityUrl = {
               logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
           }
-      
+
           def printAcceptingGradleTermsOfUse = {
               logger.lifecycle("Accepting Gradle Terms of Use: $buildScanTermsOfUseUrl")
           }
-      
+
           // finish early if DV plugin version is unsupported (v3.6.4 is the minimum version tested and supports back to DV 2021.1)
           if (develocityPluginVersion && isNotAtLeast(develocityPluginVersion, '3.6.4')) {
               logger.warn("Develocity Gradle plugin must be at least 3.6.4. Configured version is $develocityPluginVersion.")
               return
           }
-      
+
           // finish early if configuration parameters passed in via system properties are not valid/supported
           if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
               logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
               return
           }
-      
+
           // Conditionally apply and configure the Develocity plugin
           if (GradleVersion.current() < GradleVersion.version('6.0')) {
               rootProject {
                   buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
                       def resolutionResult = incoming.resolutionResult
-      
+
                       if (develocityPluginVersion) {
                           def scanPluginComponent = resolutionResult.allComponents.find {
                               it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
@@ -252,7 +252,7 @@ spec:
                               }
                           }
                       }
-      
+
                       eachDevelocityProjectExtension(project,
                           { develocity ->
                               afterEvaluate {
@@ -262,13 +262,13 @@ spec:
                                       develocity.allowUntrustedServer = develocityAllowUntrustedServer
                                   }
                               }
-      
+
                               if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                                   printAcceptingGradleTermsOfUse()
                                   develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                                   develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                               }
-      
+
                               logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
                               develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                           },
@@ -280,7 +280,7 @@ spec:
                                       buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                                   }
                               }
-      
+
                               if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                                   printAcceptingGradleTermsOfUse()
                                   if (buildScan.metaClass.respondsTo(buildScan, 'setTermsOfServiceUrl', String)) {
@@ -291,7 +291,7 @@ spec:
                                       buildScan.licenseAgree = buildScanTermsOfUseAgree
                                   }
                               }
-      
+
                               // uploadInBackground available for build-scan-plugin 3.3.4 and later only
                               if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) {
                                   logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
@@ -299,7 +299,7 @@ spec:
                               }
                           }
                       )
-      
+
                       if (ccudPluginVersion && atLeastGradle4) {
                           def ccudPluginComponent = resolutionResult.allComponents.find {
                               it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
@@ -330,11 +330,11 @@ spec:
                                   }
                               }
                           }
-      
+
                           eachDevelocitySettingsExtension(settings) { ext ->
                               ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                           }
-      
+
                           eachDevelocitySettingsExtension(settings,
                               { develocity ->
                                   logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -354,7 +354,7 @@ spec:
                           )
                       }
                   }
-      
+
                   eachDevelocitySettingsExtension(settings,
                       { develocity ->
                           if (develocityUrl && develocityEnforceUrl) {
@@ -362,13 +362,13 @@ spec:
                               develocity.server = develocityUrl
                               develocity.allowUntrustedServer = develocityAllowUntrustedServer
                           }
-      
+
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               printAcceptingGradleTermsOfUse()
                               develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                               develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                           }
-      
+
                           logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
                           develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                       },
@@ -384,13 +384,13 @@ spec:
                                   gradleEnterprise.buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                               }
                           }
-      
+
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               printAcceptingGradleTermsOfUse()
                               gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
                               gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                           }
-      
+
                           // uploadInBackground available for gradle-enterprise-plugin 3.3.4 and later only
                           if (gradleEnterprise.buildScan.metaClass.respondsTo(gradleEnterprise.buildScan, 'setUploadInBackground', Boolean)) {
                               logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
@@ -398,7 +398,7 @@ spec:
                           }
                       }
                   )
-      
+
                   if (ccudPluginVersion) {
                       if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
                           logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
@@ -408,10 +408,10 @@ spec:
               }
           }
       }
-      
+
       void applyPluginExternally(def pluginManager, String pluginClassName, String pluginVersion) {
           logger.lifecycle("Applying $pluginClassName with version $pluginVersion via init script")
-      
+
           def externallyApplied = 'develocity.externally-applied'
           def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
           def oldValue = System.getProperty(externallyApplied)
@@ -433,7 +433,7 @@ spec:
               }
           }
       }
-      
+
       /**
        * Apply the `dvAction` to all 'develocity' extensions.
        * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
@@ -442,7 +442,7 @@ spec:
       static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
           def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
           def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
-      
+
           def dvExtensions = settings.extensions.extensionsSchema.elements
               .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
               .collect { settings[it.name] }
@@ -455,7 +455,7 @@ spec:
               geExtensions.each(geAction)
           }
       }
-      
+
       /**
        * Apply the `dvAction` to the 'develocity' extension.
        * If no 'develocity' extension is found, apply the `bsAction` to the 'buildScan' extension.
@@ -464,7 +464,7 @@ spec:
       static def eachDevelocityProjectExtension(def project, def dvAction, def bsAction = dvAction) {
           def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
           def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-      
+
           def configureDvOrBsExtension = {
               if (project.extensions.findByName("develocity")) {
                   dvAction(project.develocity)
@@ -472,24 +472,24 @@ spec:
                   bsAction(project.buildScan)
               }
           }
-      
+
           project.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID, configureDvOrBsExtension)
-      
+
           project.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
               // Proper extension will be configured by the build-scan callback.
               if (project.pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) return
               configureDvOrBsExtension()
           }
       }
-      
+
       static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
           GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
       }
-      
+
       static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
           !isAtLeast(versionUnderTest, referenceVersion)
       }
-      
+
       void enableBuildScanLinkCapture(BuildScanCollector collector) {
           // Conditionally apply and configure the Develocity plugin
           if (GradleVersion.current() < GradleVersion.version('6.0')) {
@@ -507,7 +507,7 @@ spec:
               }
           }
       }
-      
+
       // Action will only be called if a `BuildScanCollector.captureBuildScanLink` method is present.
       // Add `void captureBuildScanLink(String) {}` to the `BuildScanCollector` class to respond to buildScanPublished events
       static buildScanPublishedAction(def buildScanExtension, BuildScanCollector collector) {
@@ -517,7 +517,7 @@ spec:
               }
           }
       }
-      
+
       // Custom implementation of BuildScanCollector for GitLab integration
       class BuildScanCollector {
         def captureBuildScanLink(String buildScanLink) {
@@ -539,18 +539,18 @@ spec:
           }
         }
       }
-      
+
       class Report {
         List<Link> build_scans = []
-      
+
         void addLink(String url) {
           build_scans << new Link(url)
         }
       }
-      
+
       class Link {
         Map external_link
-      
+
         Link(String url) {
           external_link = [ 'label': url, 'url': url ]
         }
@@ -655,15 +655,15 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts="-s -w \n%{http_code} -X POST"
+    local curlOpts=(-s -w \n%{http_code} -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="-k ${curlOpts}"
+      curlOpts+=(-k)
     fi
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -663,7 +663,7 @@ spec:
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@]}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -663,7 +663,7 @@ spec:
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts[@}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@]}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -655,10 +655,10 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts="-s -w \n%{http_code} -X POST"
+    local curlOpts=(-s -w \n%{http_code} -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="-k ${curlOpts}"
+    curlOpts+=(-k)
     fi
 
     while [ ${attempt} -le ${maxRetries} ]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -46,47 +46,47 @@ spec:
        * Initscript for injection of Develocity into Gradle builds.
        * Version: 1.2
        */
-
+      
       import org.gradle.util.GradleVersion
-
+      
       initscript {
           // NOTE: there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
           def isTopLevelBuild = !gradle.parent
           if (!isTopLevelBuild) {
               return
           }
-
+      
           def getInputParam = { Gradle gradle, String name ->
               def ENV_VAR_PREFIX = ''
               def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
               return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
           }
-
+      
           def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
           def initScriptName = buildscript.sourceFile.name
           if (requestedInitScriptName != initScriptName) {
               return
           }
-
+      
           // Plugin loading is only required for Develocity injection. Abort early if not enabled.
           def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
           if (!develocityInjectionEnabled) {
               return
           }
-
+      
           def pluginRepositoryUrl = getInputParam(gradle, 'gradle.plugin-repository.url')
           def pluginRepositoryUsername = getInputParam(gradle, 'gradle.plugin-repository.username')
           def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
           def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
           def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
-
+      
           def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
           def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-
+      
           if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
               pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
               logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
-
+      
               repositories {
                   maven {
                       url = pluginRepositoryUrl
@@ -103,7 +103,7 @@ spec:
                   }
               }
           }
-
+      
           dependencies {
               if (develocityPluginVersion) {
                   if (atLeastGradle5) {
@@ -116,56 +116,56 @@ spec:
                       classpath "com.gradle:build-scan-plugin:1.16"
                   }
               }
-
+      
               if (ccudPluginVersion && atLeastGradle4) {
                   classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
               }
           }
       }
-
+      
       static getInputParam(Gradle gradle, String name) {
           def ENV_VAR_PREFIX = ''
           def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
           return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
       }
-
+      
       def isTopLevelBuild = !gradle.parent
       if (!isTopLevelBuild) {
           return
       }
-
+      
       def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
       def initScriptName = buildscript.sourceFile.name
       if (requestedInitScriptName != initScriptName) {
           logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
           return
       }
-
+      
       def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
       if (develocityInjectionEnabled) {
           enableDevelocityInjection()
       }
-
+      
       // To enable build-scan capture, a `captureBuildScanLink(String)` method must be added to `BuildScanCollector`.
       def buildScanCollector = new BuildScanCollector()
       def buildScanCaptureEnabled = buildScanCollector.metaClass.respondsTo(buildScanCollector, 'captureBuildScanLink', String)
       if (buildScanCaptureEnabled) {
           enableBuildScanLinkCapture(buildScanCollector)
       }
-
+      
       void enableDevelocityInjection() {
           def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-
+      
           def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
           def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-
+      
           def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
           def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-
+      
           def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
           def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
           def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
-
+      
           def develocityUrl = getInputParam(gradle, 'develocity.url')
           def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity.allow-untrusted-server'))
           def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity.enforce-url'))
@@ -176,44 +176,44 @@ spec:
           def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity.terms-of-use.url')
           def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity.terms-of-use.agree')
           def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity.auto-injection.custom-value')
-
+      
           def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
           def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
           def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
-
+      
           def dvOrGe = { def dvValue, def geValue ->
               if (shouldApplyDevelocityPlugin) {
                   return dvValue instanceof Closure<?> ? dvValue() : dvValue
               }
               return geValue instanceof Closure<?> ? geValue() : geValue
           }
-
+      
           def printEnforcingDevelocityUrl = {
               logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
           }
-
+      
           def printAcceptingGradleTermsOfUse = {
               logger.lifecycle("Accepting Gradle Terms of Use: $buildScanTermsOfUseUrl")
           }
-
+      
           // finish early if DV plugin version is unsupported (v3.6.4 is the minimum version tested and supports back to DV 2021.1)
           if (develocityPluginVersion && isNotAtLeast(develocityPluginVersion, '3.6.4')) {
               logger.warn("Develocity Gradle plugin must be at least 3.6.4. Configured version is $develocityPluginVersion.")
               return
           }
-
+      
           // finish early if configuration parameters passed in via system properties are not valid/supported
           if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
               logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
               return
           }
-
+      
           // Conditionally apply and configure the Develocity plugin
           if (GradleVersion.current() < GradleVersion.version('6.0')) {
               rootProject {
                   buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
                       def resolutionResult = incoming.resolutionResult
-
+      
                       if (develocityPluginVersion) {
                           def scanPluginComponent = resolutionResult.allComponents.find {
                               it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
@@ -252,7 +252,7 @@ spec:
                               }
                           }
                       }
-
+      
                       eachDevelocityProjectExtension(project,
                           { develocity ->
                               afterEvaluate {
@@ -262,13 +262,13 @@ spec:
                                       develocity.allowUntrustedServer = develocityAllowUntrustedServer
                                   }
                               }
-
+      
                               if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                                   printAcceptingGradleTermsOfUse()
                                   develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                                   develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                               }
-
+      
                               logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
                               develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                           },
@@ -280,7 +280,7 @@ spec:
                                       buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                                   }
                               }
-
+      
                               if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                                   printAcceptingGradleTermsOfUse()
                                   if (buildScan.metaClass.respondsTo(buildScan, 'setTermsOfServiceUrl', String)) {
@@ -291,7 +291,7 @@ spec:
                                       buildScan.licenseAgree = buildScanTermsOfUseAgree
                                   }
                               }
-
+      
                               // uploadInBackground available for build-scan-plugin 3.3.4 and later only
                               if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) {
                                   logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
@@ -299,7 +299,7 @@ spec:
                               }
                           }
                       )
-
+      
                       if (ccudPluginVersion && atLeastGradle4) {
                           def ccudPluginComponent = resolutionResult.allComponents.find {
                               it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
@@ -330,11 +330,11 @@ spec:
                                   }
                               }
                           }
-
+      
                           eachDevelocitySettingsExtension(settings) { ext ->
                               ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                           }
-
+      
                           eachDevelocitySettingsExtension(settings,
                               { develocity ->
                                   logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -354,7 +354,7 @@ spec:
                           )
                       }
                   }
-
+      
                   eachDevelocitySettingsExtension(settings,
                       { develocity ->
                           if (develocityUrl && develocityEnforceUrl) {
@@ -362,13 +362,13 @@ spec:
                               develocity.server = develocityUrl
                               develocity.allowUntrustedServer = develocityAllowUntrustedServer
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               printAcceptingGradleTermsOfUse()
                               develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                               develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                           }
-
+      
                           logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
                           develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                       },
@@ -384,13 +384,13 @@ spec:
                                   gradleEnterprise.buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                               }
                           }
-
+      
                           if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
                               printAcceptingGradleTermsOfUse()
                               gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
                               gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                           }
-
+      
                           // uploadInBackground available for gradle-enterprise-plugin 3.3.4 and later only
                           if (gradleEnterprise.buildScan.metaClass.respondsTo(gradleEnterprise.buildScan, 'setUploadInBackground', Boolean)) {
                               logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
@@ -398,7 +398,7 @@ spec:
                           }
                       }
                   )
-
+      
                   if (ccudPluginVersion) {
                       if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
                           logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
@@ -408,10 +408,10 @@ spec:
               }
           }
       }
-
+      
       void applyPluginExternally(def pluginManager, String pluginClassName, String pluginVersion) {
           logger.lifecycle("Applying $pluginClassName with version $pluginVersion via init script")
-
+      
           def externallyApplied = 'develocity.externally-applied'
           def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
           def oldValue = System.getProperty(externallyApplied)
@@ -433,7 +433,7 @@ spec:
               }
           }
       }
-
+      
       /**
        * Apply the `dvAction` to all 'develocity' extensions.
        * If no 'develocity' extensions are found, apply the `geAction` to all 'gradleEnterprise' extensions.
@@ -442,7 +442,7 @@ spec:
       static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAction = dvAction) {
           def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
           def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
-
+      
           def dvExtensions = settings.extensions.extensionsSchema.elements
               .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
               .collect { settings[it.name] }
@@ -455,7 +455,7 @@ spec:
               geExtensions.each(geAction)
           }
       }
-
+      
       /**
        * Apply the `dvAction` to the 'develocity' extension.
        * If no 'develocity' extension is found, apply the `bsAction` to the 'buildScan' extension.
@@ -464,7 +464,7 @@ spec:
       static def eachDevelocityProjectExtension(def project, def dvAction, def bsAction = dvAction) {
           def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
           def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-
+      
           def configureDvOrBsExtension = {
               if (project.extensions.findByName("develocity")) {
                   dvAction(project.develocity)
@@ -472,24 +472,24 @@ spec:
                   bsAction(project.buildScan)
               }
           }
-
+      
           project.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID, configureDvOrBsExtension)
-
+      
           project.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
               // Proper extension will be configured by the build-scan callback.
               if (project.pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) return
               configureDvOrBsExtension()
           }
       }
-
+      
       static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
           GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
       }
-
+      
       static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
           !isAtLeast(versionUnderTest, referenceVersion)
       }
-
+      
       void enableBuildScanLinkCapture(BuildScanCollector collector) {
           // Conditionally apply and configure the Develocity plugin
           if (GradleVersion.current() < GradleVersion.version('6.0')) {
@@ -507,7 +507,7 @@ spec:
               }
           }
       }
-
+      
       // Action will only be called if a `BuildScanCollector.captureBuildScanLink` method is present.
       // Add `void captureBuildScanLink(String) {}` to the `BuildScanCollector` class to respond to buildScanPublished events
       static buildScanPublishedAction(def buildScanExtension, BuildScanCollector collector) {
@@ -517,7 +517,7 @@ spec:
               }
           }
       }
-
+      
       // Custom implementation of BuildScanCollector for GitLab integration
       class BuildScanCollector {
         def captureBuildScanLink(String buildScanLink) {
@@ -539,18 +539,18 @@ spec:
           }
         }
       }
-
+      
       class Report {
         List<Link> build_scans = []
-
+      
         void addLink(String url) {
           build_scans << new Link(url)
         }
       }
-
+      
       class Link {
         Map external_link
-
+      
         Link(String url) {
           external_link = [ 'label': url, 'url': url ]
         }
@@ -655,15 +655,15 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts=(-s -w \n%{http_code} -X POST)
+    local curlOpts="-s -w \n%{http_code} -X POST"
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts+=(-k)
+      curlOpts="-k ${curlOpts}"
     fi
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts[@]}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -659,7 +659,7 @@ spec:
     if [ "${allowUntrusted}" == "true" ]; then
       curlOpts="${curlOpts} -k"
     fi
-  
+
     while [ ${attempt} -le ${maxRetries} ]
     do
       local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -570,6 +570,7 @@ spec:
 
     local serverUrl=${1}
     local expiry="${2}"
+    local allowUntrusted="${3}"
 
     local newAccessKey=""
     if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
@@ -579,7 +580,7 @@ spec:
       local tokenUrl="${serverUrl}/api/auth/token"
       if [ ! -z "${accessKey}" ]
       then
-        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           newAccessKey="${hostname}=${token}"
@@ -593,7 +594,7 @@ spec:
       for pair in "${pairs[@]}"; do
         IFS='=' read -r host key <<< "$pair"
         local tokenUrl="https://${host}/api/auth/token"
-        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        local token=$(getShortLivedToken $tokenUrl $expiry $key $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           if [ -z "${newAccessKey}" ]
@@ -644,6 +645,7 @@ spec:
     local tokenUrl=$1
     local expiry=$2
     local accessKey=$3
+    local allowUntrusted=$4
     local maxRetries=3
     local retryInterval=1
     local attempt=0
@@ -652,9 +654,15 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
+    
+    local curlOpts="-s -w \n%{http_code} -X POST"
+    if [ "${allowUntrusted}" == "true" ]; then
+      curlOpts="${curlOpts} -k"
+    fi
+  
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
@@ -688,5 +696,5 @@ spec:
   }
 
   createGradleInit
-  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
+  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]" "$[[ inputs.allowUntrustedServer ]]"
   injectDevelocityForGradle

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -275,7 +275,7 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts=(-s -w \n%{http_code} -X POST)
+    local curlOpts=(-s -w "\n%{http_code}" -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
       curlOpts+=(-k)

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -278,7 +278,7 @@ spec:
     local curlOpts="-s -w \n%{http_code} -X POST"
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="${curlOpts} -k"
+      curlOpts="-k ${curlOpts}"
     fi
 
     while [ ${attempt} -le ${maxRetries} ]

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -283,7 +283,7 @@ spec:
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts[@}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@]}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -190,6 +190,7 @@ spec:
 
     local serverUrl=${1}
     local expiry="${2}"
+    local allowUntrusted="${3}"
 
     local newAccessKey=""
     if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
@@ -199,7 +200,7 @@ spec:
       local tokenUrl="${serverUrl}/api/auth/token"
       if [ ! -z "${accessKey}" ]
       then
-        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           newAccessKey="${hostname}=${token}"
@@ -213,7 +214,7 @@ spec:
       for pair in "${pairs[@]}"; do
         IFS='=' read -r host key <<< "$pair"
         local tokenUrl="https://${host}/api/auth/token"
-        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        local token=$(getShortLivedToken $tokenUrl $expiry $key $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           if [ -z "${newAccessKey}" ]
@@ -264,6 +265,7 @@ spec:
     local tokenUrl=$1
     local expiry=$2
     local accessKey=$3
+    local allowUntrusted=$4
     local maxRetries=3
     local retryInterval=1
     local attempt=0
@@ -272,9 +274,15 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
+    
+    local curlOpts="-s -w \n%{http_code} -X POST"
+    if [ "${allowUntrusted}" == "true" ]; then
+      curlOpts="${curlOpts} -k"
+    fi
+    
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
@@ -296,5 +304,5 @@ spec:
   createTmp
   downloadDvCcudExt
   downloadDvMavenExt
-  createShortLivedToken "${url}" "${shortLivedTokensExpiry}"
+  createShortLivedToken "${url}" "${shortLivedTokensExpiry}" "${allowUntrustedServer}"
   injectDevelocityForMaven "${PWD}"

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -275,15 +275,15 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts="-s -w \n%{http_code} -X POST"
+    local curlOpts=(-s -w \n%{http_code} -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="-k ${curlOpts}"
+      curlOpts+=(-k)
     fi
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/develocity-maven.yml
+++ b/develocity-maven.yml
@@ -274,15 +274,16 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
-    
+
     local curlOpts="-s -w \n%{http_code} -X POST"
-    if [ "${allowUntrusted}" == "true" ]; then
+    if [ "${allowUntrusted}" == "true" ];
+    then
       curlOpts="${curlOpts} -k"
     fi
-    
+
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -146,7 +146,7 @@ spec:
     local curlOpts="-s -w \n%{http_code} -X POST"
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="${curlOpts} -k"
+      curlOpts="-k ${curlOpts}"
     fi
 
     while [ ${attempt} -le ${maxRetries} ]

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -143,10 +143,10 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts="-s -w \n%{http_code} -X POST"
+    local curlOpts=(-s -w \n%{http_code} -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
-      curlOpts="-k ${curlOpts}"
+    curlOpts+=(-k)
     fi
 
     while [ ${attempt} -le ${maxRetries} ]

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -58,6 +58,7 @@ spec:
 
     local serverUrl=${1}
     local expiry="${2}"
+    local allowUntrusted="${3}"
 
     local newAccessKey=""
     if [[ "${enforceUrl}" == "true" || $(singleKey "${allKeys}") == "true" ]]
@@ -67,7 +68,7 @@ spec:
       local tokenUrl="${serverUrl}/api/auth/token"
       if [ ! -z "${accessKey}" ]
       then
-        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey)
+        local token=$(getShortLivedToken $tokenUrl $expiry $accessKey $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           newAccessKey="${hostname}=${token}"
@@ -81,7 +82,7 @@ spec:
       for pair in "${pairs[@]}"; do
         IFS='=' read -r host key <<< "$pair"
         local tokenUrl="https://${host}/api/auth/token"
-        local token=$(getShortLivedToken $tokenUrl $expiry $key)
+        local token=$(getShortLivedToken $tokenUrl $expiry $key $allowUntrusted)
         if [ ! -z "${token}" ]
         then
           if [ -z "${newAccessKey}" ]
@@ -140,9 +141,15 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
+    
+    local curlOpts="-s -w \n%{http_code} -X POST"
+    if [ "${allowUntrusted}" == "true" ]; then
+      curlOpts="${curlOpts} -k"
+    fi
+
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl -s -w "\n%{http_code}" -X POST "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]
@@ -176,5 +183,5 @@ spec:
   }
 
   createGradleInit
-  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]"
+  createShortLivedToken "$[[ inputs.url ]]" "$[[ inputs.shortLivedTokensExpiry ]]" "$[[ inputs.allowUntrustedServer ]]"
   injectDevelocityForGradle

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -142,15 +142,16 @@ spec:
     then
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
-    
+
     local curlOpts="-s -w \n%{http_code} -X POST"
-    if [ "${allowUntrusted}" == "true" ]; then
+    if [ "${allowUntrusted}" == "true" ];
+    then
       curlOpts="${curlOpts} -k"
     fi
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl ${curlOpts} "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -151,7 +151,7 @@ spec:
 
     while [ ${attempt} -le ${maxRetries} ]
     do
-      local response=$(curl "${curlOpts}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
+      local response=$(curl "${curlOpts[@]}" "${tokenUrl}" -H "Authorization: Bearer ${accessKey}")
       local status_code=$(tail -n1 <<< "${response}")
       local shortLivedToken=$(head -n -1 <<< "${response}")
       if [[ "${status_code}" == "200" && ! -z "${shortLivedToken}" ]]

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -133,6 +133,7 @@ spec:
     local tokenUrl=$1
     local expiry=$2
     local accessKey=$3
+    local allowUntrusted=$4
     local maxRetries=3
     local retryInterval=1
     local attempt=0

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -143,7 +143,7 @@ spec:
       tokenUrl="${tokenUrl}?expiresInHours=${expiry}"
     fi
 
-    local curlOpts=(-s -w \n%{http_code} -X POST)
+    local curlOpts=(-s -w "\n%{http_code}" -X POST)
     if [ "${allowUntrusted}" == "true" ];
     then
     curlOpts+=(-k)


### PR DESCRIPTION
If a user allows a build scan to be published to an untrusted server (can be enabled in the Develocity Injection configuration via UI), this PR makes sure to ignore any SSL errors when we resolve a short-lived token from that server.