### PR TITLE
Add copyInitScriptToGradleUserHome input for automatic init script installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,29 @@ The templates can also be configured to ad-hoc connect Gradle and Maven builds t
 ## Configuration
 ### Gradle Auto-instrumentation
 Include the remote template and optionally pass inputs.
-To enable Build Scan publishing for Gradle builds, the configuration would look something like presented below (using https://develocity.example.com as an example of Develocity server URL.
+To enable Build Scan publishing for Gradle builds, the configuration would look something like presented below (using https://develocity.example.com as an example of Develocity server URL).
+
+> **_NOTE:_** The build is also instrumented with our [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) as well, as it will provide more details about your build.
+
+#### Recommended: automatic init script installation
+
+Set `copyInitScriptToGradleUserHome: 'true'` to have the template install the init script into `$GRADLE_USER_HOME/init.d/`. Gradle discovers and applies scripts in that directory automatically, so no `-I` flag is needed on any `gradlew` invocation.
 
 ```yml
 include:
   - remote: 'https://raw.githubusercontent.com/gradle/develocity-gitlab-templates/1.3.4/develocity-gradle.yml'
     inputs:
       url: https://develocity.example.com
+      copyInitScriptToGradleUserHome: 'true'
 
 build-gradle-job:
   stage: build
   script:
     - !reference [.injectDevelocityForGradle]
-    - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH # Will publish a build scan to https://develocity.example.com
+    - ./gradlew check # Will publish a build scan to https://develocity.example.com
 ```
-The `.injectDevelocityForGradle` creates an init script with the instrumentation logic and exports the path as `$DEVELOCITY_INIT_SCRIPT_PATH` environment variable.
-For all other options see `inputs` section in [develocity-gradle.yml](develocity-gradle.yml).
 
-> **_NOTE:_** The build is also instrumented with our [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) as well, as it will provide more details about your build.
+For all other options see `inputs` section in [develocity-gradle.yml](develocity-gradle.yml).
 
 #### Build Scan links
 An optional init script can be used to generate a report containing Build Scan links.
@@ -49,13 +54,14 @@ include:
   - remote: 'https://raw.githubusercontent.com/gradle/develocity-gitlab-templates/main/develocity-gradle.yml'
     inputs:
       url: https://develocity.example.com
+      copyInitScriptToGradleUserHome: 'true'
 
 build-gradle-job:
   stage: build
   script:
     - !reference [.injectDevelocityForGradle]
-    - ./gradlew clean -I $DEVELOCITY_INIT_SCRIPT_PATH
-    - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH
+    - ./gradlew clean
+    - ./gradlew check
     # Attach the report
   artifacts:
     !reference [ .build_scan_links_report, artifacts ]
@@ -78,13 +84,33 @@ build-gradle-job:
     stage: build
     extends: .gradle-inject-job
     script:
-        - ./gradlew build -I $DEVELOCITY_INIT_SCRIPT_PATH
+        - ./gradlew build
 
 test-gradle-job:
     stage: build
     extends: .gradle-inject-job
     script:
-        - ./gradlew test -I $DEVELOCITY_INIT_SCRIPT_PATH
+        - ./gradlew test
+```
+
+#### Deprecated: manual `-I` flag
+
+> [!WARNING]
+> This approach is deprecated. Use `copyInitScriptToGradleUserHome: 'true'` instead.
+
+When `copyInitScriptToGradleUserHome` is `false` (the default for backwards compatibility), `.injectDevelocityForGradle` writes the init script to `$CI_PROJECT_DIR` and exports its path as `$DEVELOCITY_INIT_SCRIPT_PATH`. The flag must be passed explicitly to every `gradlew` invocation:
+
+```yml
+include:
+  - remote: 'https://raw.githubusercontent.com/gradle/develocity-gitlab-templates/1.3.4/develocity-gradle.yml'
+    inputs:
+      url: https://develocity.example.com
+
+build-gradle-job:
+  stage: build
+  script:
+    - !reference [.injectDevelocityForGradle]
+    - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH
 ```
 
 ### Maven Auto-instrumentation
@@ -119,6 +145,7 @@ include:
   - remote: "https://raw.githubusercontent.com/gradle/develocity-gitlab-templates/1.3.4/develocity-gradle.yml"
     inputs:
       url: https://develocity.example.com
+      copyInitScriptToGradleUserHome: 'true'
   - remote: "https://raw.githubusercontent.com/gradle/develocity-gitlab-templates/1.3.4/develocity-maven.yml"
     inputs:
       url: https://develocity.example.com
@@ -133,7 +160,7 @@ build-gradle-job:
   stage: build
   script:
     - !reference [.injectDevelocityForGradle]
-    - ./gradlew check -I $DEVELOCITY_INIT_SCRIPT_PATH # Will publish a build scan to https://develocity.example.com
+    - ./gradlew check # Will publish a build scan to https://develocity.example.com
 ```
 
 ### Auto-instrumentation compatibility

--- a/develocity-gradle.yml
+++ b/develocity-gradle.yml
@@ -30,6 +30,10 @@ spec:
     # Enforce the url over any defined locally to the project
     enforceUrl:
       default: 'false'
+    # Copy the init script to $GRADLE_USER_HOME/init.d/ so Gradle applies it automatically without -I.
+    # Recommended over the -I approach. When true, DEVELOCITY_INIT_SCRIPT_PATH is not exported.
+    copyInitScriptToGradleUserHome:
+      default: 'false'
 
 ---
 .build_scan_links_report:
@@ -39,9 +43,16 @@ spec:
 
 .injectDevelocityForGradle: |
   function createGradleInit() {
-    local initScript="${CI_PROJECT_DIR}/init-script.gradle"
+    if [ "${copyInitScriptToGradleUserHome}" == "true" ]; then
+      local gradleUserHome="${GRADLE_USER_HOME:-${HOME}/.gradle}"
+      local initScript="${gradleUserHome}/init.d/develocity-injection.gradle"
+      mkdir -p "${gradleUserHome}/init.d"
+    else
+      local initScript="${CI_PROJECT_DIR}/init-script.gradle"
+      export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
+    fi
 
-    cat > $initScript <<'EOF'
+    cat > "${initScript}" <<'EOF'
       /*
        * Initscript for injection of Develocity into Gradle builds.
        * Version: 2.0.1
@@ -572,7 +583,6 @@ spec:
       }
   EOF
 
-    export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
     export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
   }
 
@@ -586,6 +596,7 @@ spec:
   gradlePluginRepositoryUsername=$[[ inputs.gradlePluginRepositoryUsername ]]
   gradlePluginRepositoryPassword=$[[ inputs.gradlePluginRepositoryPassword ]]
   url=$[[ inputs.url ]]
+  copyInitScriptToGradleUserHome=$[[ inputs.copyInitScriptToGradleUserHome ]]
 
   function createShortLivedToken() {
     local allKeys="${GRADLE_ENTERPRISE_ACCESS_KEY:-${DEVELOCITY_ACCESS_KEY}}"
@@ -710,7 +721,15 @@ spec:
   function injectDevelocityForGradle() {
     export "DEVELOCITY_INJECTION_ENABLED=true"
     export "DEVELOCITY_INJECTION_DEBUG=true"
-    export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
+    # The init script guards itself by comparing its own filename against this value. Gradle applies
+    # all init scripts it discovers — both via -I and from $GRADLE_USER_HOME/init.d/ — so if the
+    # script exists in both locations simultaneously, only the one whose filename matches will
+    # proceed; the other returns early. This prevents double-application without requiring cleanup.
+    if [ "${copyInitScriptToGradleUserHome}" == "true" ]; then
+      export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=develocity-injection.gradle"
+    else
+      export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
+    fi
     export "DEVELOCITY_INJECTION_CUSTOM_VALUE=GitLab"
     export "DEVELOCITY_INJECTION_URL=${url}"
     export "DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION=${gradlePluginVersion}"

--- a/src/gradle/develocity-gradle.template.yml
+++ b/src/gradle/develocity-gradle.template.yml
@@ -30,6 +30,10 @@ spec:
     # Enforce the url over any defined locally to the project
     enforceUrl:
       default: 'false'
+    # Copy the init script to $GRADLE_USER_HOME/init.d/ so Gradle applies it automatically without -I.
+    # Recommended over the -I approach. When true, DEVELOCITY_INIT_SCRIPT_PATH is not exported.
+    copyInitScriptToGradleUserHome:
+      default: 'false'
 
 ---
 .build_scan_links_report:
@@ -39,13 +43,19 @@ spec:
 
 .injectDevelocityForGradle: |
   function createGradleInit() {
-    local initScript="${CI_PROJECT_DIR}/init-script.gradle"
+    if [ "${copyInitScriptToGradleUserHome}" == "true" ]; then
+      local gradleUserHome="${GRADLE_USER_HOME:-${HOME}/.gradle}"
+      local initScript="${gradleUserHome}/init.d/develocity-injection.gradle"
+      mkdir -p "${gradleUserHome}/init.d"
+    else
+      local initScript="${CI_PROJECT_DIR}/init-script.gradle"
+      export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
+    fi
 
-    cat > $initScript <<'EOF'
+    cat > "${initScript}" <<'EOF'
 <<DEVELOCITY_INJECTION_INIT_GRADLE>>
   EOF
 
-    export DEVELOCITY_INIT_SCRIPT_PATH="${initScript}"
     export BUILD_SCAN_REPORT_PATH="${CI_PROJECT_DIR}/build-scan-links.json"
   }
 
@@ -59,6 +69,7 @@ spec:
   gradlePluginRepositoryUsername=$[[ inputs.gradlePluginRepositoryUsername ]]
   gradlePluginRepositoryPassword=$[[ inputs.gradlePluginRepositoryPassword ]]
   url=$[[ inputs.url ]]
+  copyInitScriptToGradleUserHome=$[[ inputs.copyInitScriptToGradleUserHome ]]
 
   function createShortLivedToken() {
     local allKeys="${GRADLE_ENTERPRISE_ACCESS_KEY:-${DEVELOCITY_ACCESS_KEY}}"
@@ -183,7 +194,15 @@ spec:
   function injectDevelocityForGradle() {
     export "DEVELOCITY_INJECTION_ENABLED=true"
     export "DEVELOCITY_INJECTION_DEBUG=true"
-    export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
+    # The init script guards itself by comparing its own filename against this value. Gradle applies
+    # all init scripts it discovers — both via -I and from $GRADLE_USER_HOME/init.d/ — so if the
+    # script exists in both locations simultaneously, only the one whose filename matches will
+    # proceed; the other returns early. This prevents double-application without requiring cleanup.
+    if [ "${copyInitScriptToGradleUserHome}" == "true" ]; then
+      export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=develocity-injection.gradle"
+    else
+      export "DEVELOCITY_INJECTION_INIT_SCRIPT_NAME=init-script.gradle"
+    fi
     export "DEVELOCITY_INJECTION_CUSTOM_VALUE=GitLab"
     export "DEVELOCITY_INJECTION_URL=${url}"
     export "DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION=${gradlePluginVersion}"


### PR DESCRIPTION
## Changes

- Added `copyInitScriptToGradleUserHome` input to enable automatic init script installation into `$GRADLE_USER_HOME/init.d/`
- When enabled, Gradle discovers and applies the init script automatically without requiring `-I` flag
- Updated documentation with recommended approach and deprecated `-I` flag method
- Init script now conditionally installs to either `$GRADLE_USER_HOME/init.d/` or `$CI_PROJECT_DIR` based on input
- Added logic to prevent double-application when script exists in both locations
- Updated template and generated YAML files with new input parameter

## Breaking Changes
None - new feature is opt-in with default value of `false` for backwards compatibility

Note: you can see a run with these [changes](https://gitlab.com/ribafish/common-custom-user-data-gradle-plugin/-/blob/main/.gitlab-ci.yml?ref_type=heads#L28-31) applied [here](https://gitlab.com/ribafish/common-custom-user-data-gradle-plugin/-/jobs/13428818207)