### PR TITLE
Replace stale gradle.com references with develocity.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,23 +166,23 @@ build-gradle-job:
 ### Auto-instrumentation compatibility
 The following sections list the compatibility of the instrumented Develocity Gradle plugin and Develocity Maven extension with the Develocity version based on the given build tool in use.
 #### For Gradle builds
-For Gradle builds the version used for the Develocity Gradle plugin can be defined with the `gradlePluginVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.gradle.com/enterprise/compatibility/#develocity_gradle_plugin).
+For Gradle builds the version used for the Develocity Gradle plugin can be defined with the `gradlePluginVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.develocity.ai/current/miscellaneous/compatibility/).
 For the Common Custom User Data Gradle plugin which is defined with the `ccudPluginVersion` input, you can see the compatibility of the specified version with the Develocity Gradle plugin [here](https://github.com/gradle/common-custom-user-data-gradle-plugin#version-compatibility).
 
 #### For Maven builds
-For Maven builds the version used for the Develocity Maven extension can be defined with the `mavenExtensionVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.gradle.com/develocity/maven/current/maven-extension/#compatibility-with-apache-maven-and-develocity).
+For Maven builds the version used for the Develocity Maven extension can be defined with the `mavenExtensionVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.develocity.ai/maven/current/maven-extension/#compatibility-with-apache-maven-and-develocity).
 For the Common Custom User Data Maven extension which is defined with the `ccudMavenExtensionVersion` input, you can see the compatibility of the specified version with the Develocity Maven extension [here](https://github.com/gradle/common-custom-user-data-maven-extension#version-compatibility).
 
 ## Authentication
 To authenticate against the Develocity server, you should specify a masked environment variable named `DEVELOCITY_ACCESS_KEY`.
 See [here](https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-ui) on how to do this in GitLab UI.
-To generate a Develocity Access Key, you can check [Develocity Gradle plugin docs](https://docs.gradle.com/develocity/gradle/current/gradle-plugin/#manual-access-key-configuration) and [Develocity Maven extension docs](https://docs.gradle.com/develocity/maven/current/maven-extension/#manual-access-key-configuration).
+To generate a Develocity Access Key, you can check [Develocity Gradle plugin docs](https://docs.develocity.ai/gradle/current/gradle-plugin/#manual-access-key-configuration) and [Develocity Maven extension docs](https://docs.develocity.ai/maven/current/maven-extension/#manual-access-key-configuration).
 
 ### Short-lived access tokens
 Develocity access keys are long-lived, creating risks if they are leaked. To avoid this, users can use short-lived access tokens to authenticate with Develocity. Access tokens can be used wherever an access key would be used. Access tokens are only valid for the Develocity instance that created them.
 If a short-lived token fails to be retrieved (for example, if the Develocity server version is lower than `2024.1`), no access key will be set.
 In that case, Develocity authenticated operations like build cache read/write and build scan publication will fail without failing the build.
-For more information on short-lived tokens, see [Develocity API documentation](https://docs.gradle.com/develocity/current/reference/develocity-api/#short-lived-access-tokens).
+For more information on short-lived tokens, see [Develocity API documentation](https://docs.develocity.ai/current/reference/develocity-api/#short-lived-access-tokens).
 
 
 ## License


### PR DESCRIPTION
Updates stale `gradle.com` references to their current canonical destinations. `gradle.com` and `docs.gradle.com` URLs now redirect to `develocity.ai` / `docs.develocity.ai`; this updates them to the canonical hosts.

**Changes** (`README.md`)
- Doc links `docs.gradle.com/develocity/...` → `docs.develocity.ai/...` (Gradle plugin, Maven extension, Develocity API)
- Compatibility link `docs.gradle.com/enterprise/compatibility/#develocity_gradle_plugin` → `docs.develocity.ai/current/miscellaneous/compatibility/`

⚠️ **Review note**: the old compatibility link used a `#develocity_gradle_plugin` anchor; the page was restructured, so the anchor was dropped (links to the compatibility page top). Please point it at the correct section anchor if one exists.
