### PR TITLE
Update Develocity docs links to docs.develocity.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,19 +170,19 @@ For Gradle builds the version used for the Develocity Gradle plugin can be defin
 For the Common Custom User Data Gradle plugin which is defined with the `ccudPluginVersion` input, you can see the compatibility of the specified version with the Develocity Gradle plugin [here](https://github.com/gradle/common-custom-user-data-gradle-plugin#version-compatibility).
 
 #### For Maven builds
-For Maven builds the version used for the Develocity Maven extension can be defined with the `mavenExtensionVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.gradle.com/develocity/maven/current/maven-extension/#compatibility-with-apache-maven-and-develocity).
+For Maven builds the version used for the Develocity Maven extension can be defined with the `mavenExtensionVersion` input. The compatibility of the specified version with Develocity can be found [here](https://docs.develocity.ai/maven/current/maven-extension/#compatibility-with-apache-maven-and-develocity).
 For the Common Custom User Data Maven extension which is defined with the `ccudMavenExtensionVersion` input, you can see the compatibility of the specified version with the Develocity Maven extension [here](https://github.com/gradle/common-custom-user-data-maven-extension#version-compatibility).
 
 ## Authentication
 To authenticate against the Develocity server, you should specify a masked environment variable named `DEVELOCITY_ACCESS_KEY`.
 See [here](https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-ui) on how to do this in GitLab UI.
-To generate a Develocity Access Key, you can check [Develocity Gradle plugin docs](https://docs.gradle.com/develocity/gradle/current/gradle-plugin/#manual-access-key-configuration) and [Develocity Maven extension docs](https://docs.gradle.com/develocity/maven/current/maven-extension/#manual-access-key-configuration).
+To generate a Develocity Access Key, you can check [Develocity Gradle plugin docs](https://docs.develocity.ai/gradle/current/gradle-plugin/#manual-access-key-configuration) and [Develocity Maven extension docs](https://docs.develocity.ai/maven/current/maven-extension/#manual-access-key-configuration).
 
 ### Short-lived access tokens
 Develocity access keys are long-lived, creating risks if they are leaked. To avoid this, users can use short-lived access tokens to authenticate with Develocity. Access tokens can be used wherever an access key would be used. Access tokens are only valid for the Develocity instance that created them.
 If a short-lived token fails to be retrieved (for example, if the Develocity server version is lower than `2024.1`), no access key will be set.
 In that case, Develocity authenticated operations like build cache read/write and build scan publication will fail without failing the build.
-For more information on short-lived tokens, see [Develocity API documentation](https://docs.gradle.com/develocity/current/reference/develocity-api/#short-lived-access-tokens).
+For more information on short-lived tokens, see [Develocity API documentation](https://docs.develocity.ai/current/reference/develocity-api/#short-lived-access-tokens).
 
 
 ## License


### PR DESCRIPTION
Point the four Develocity documentation links (Maven extension compatibility, Gradle plugin and Maven extension access-key configuration, and the Develocity API short-lived tokens reference) at the canonical docs domain `docs.develocity.ai` instead of the legacy `docs.gradle.com/develocity` path.

`docs.gradle.com/develocity/…` now issues a 301 to `docs.develocity.ai/…`; these link directly to the destination. No content change — same pages and anchors.